### PR TITLE
docs(readme): add project overview and team

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,78 @@
-# Typocalypse — Terminal Dojo
+# Typocalypse — Terminal Dojo 🧠💻
 
-Initial scaffold.
+Terminal Dojo is a game-like CLI training app for RS School Tandem.
+Users practice real Linux terminal thinking in a **safe simulated sandbox** (no OS execution), solve missions, get feedback, and track progress.
+
+---
+
+## Team 👥
+
+> Course-required format: **Name + GitHub link**.
+
+- **TL: Yermek Yerdenov** — https://github.com/yermekyerden
+- **Denis Nasonov** — https://github.com/JasonScriptLord
+- **Yesset Bimanov** — https://github.com/YessetHumanMan
+- **Alessya Tkachenko** — https://github.com/BerserkBat
+- **Roman Plis** — https://github.com/romanplis
+- **Mentor: Igor Moskalev** — https://github.com/ivmoskalev
+
+---
+
+## What we’re building 🎯
+
+A mission-based “terminal dojo” where users type commands in a controlled environment.
+The app validates results (**state/output**), explains mistakes, and helps build real CLI habits.
+
+---
+
+## MVP scope ✅
+
+- 🖥️ Terminal-like UI + input experience
+- 🧩 Safe command subset (simulated, no OS execution)
+- 🗂️ Virtual File System (VFS) for deterministic missions
+- 🧪 Mission runner + validators (state/output checks)
+- 💡 Clear failure feedback (“what failed and why”)
+- 📈 Progress tracking (local-first)
+
+---
+
+## Tech stack (planned) 🛠️
+
+### Frontend 🎨
+- ⚛️ React + TypeScript (**strict**)
+- 🌬️ Tailwind CSS
+- 🧱 shadcn/ui (Tailwind-based components)
+
+### Backend 🧰
+- 🪺 NestJS (Node.js)
+
+---
+
+## Limitations (by design) 🧱
+
+- 🐚 Not a full Bash implementation (only documented subset)
+- 🔒 No arbitrary code execution, no OS commands
+- 📜 Only supported commands/features will be documented
+
+---
+
+## Repository workflow 🧭
+
+- 🌿 `main` — default/stable branch (checkpoints + release snapshots)
+- 🧪 `develop` — integration branch for day-to-day work
+- 🧵 feature branches — `feat/*`, `fix/*`, `docs/*`, `chore/*` → PR → merge into `develop`
+- 📝 `diary` — diary-only branch (`development-notes/**`) → PR → merge into `main`
+
+---
+
+## Links 🔗
+
+- 📌 Project board: TBD
+- 🚀 Deploy: TBD
+- 📚 Docs: TBD
+
+---
+
+## How to run 🚀
+
+Coming soon.


### PR DESCRIPTION
## Summary
Replace the initial scaffold README with a clear project overview and team list.

## Changes
- Added short project description and MVP scope
- Added team section (Name + GitHub link)
- Documented planned tech stack and repository workflow
