### PR TITLE
feat(contracts): lesson-centric API contracts and lesson-mission mapping

### DIFF
--- a/backend/prisma/migrations/20260329125823_add_lesson_id_to_attempt/migration.sql
+++ b/backend/prisma/migrations/20260329125823_add_lesson_id_to_attempt/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Attempt" ADD COLUMN "lessonId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Attempt_userId_lessonId_idx" ON "Attempt"("userId", "lessonId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -10,6 +10,7 @@ datasource db {
 model Attempt {
   id             String    @id @default(uuid())
   userId         String
+  lessonId       String?   // null for rows predating this migration; no backfill
   missionId      String
   missionVersion Int
   status         String    // AttemptStatus: "in_progress" | "completed" | "abandoned"
@@ -24,6 +25,7 @@ model Attempt {
 
   @@index([userId])
   @@index([userId, missionId])
+  @@index([userId, lessonId])
 }
 
 model AttemptStep {

--- a/backend/src/attempts/attempts.controller.spec.ts
+++ b/backend/src/attempts/attempts.controller.spec.ts
@@ -1,0 +1,125 @@
+import { ConflictException, ForbiddenException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AttemptsController } from './attempts.controller';
+import { AttemptsService } from './attempts.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+
+void JwtAuthGuard;
+
+const MOCK_USER = { id: 'user-1' };
+const MOCK_ATTEMPT_ID = 'attempt-uuid';
+
+describe('AttemptsController', () => {
+  let controller: AttemptsController;
+  let attemptsService: jest.Mocked<AttemptsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AttemptsController],
+      providers: [
+        {
+          provide: AttemptsService,
+          useValue: {
+            createAttempt: jest.fn(),
+            getAttempt: jest.fn(),
+            submitCommand: jest.fn(),
+            abandonAttempt: jest.fn(),
+          },
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get(AttemptsController);
+    attemptsService = module.get(AttemptsService);
+  });
+
+  describe('createAttempt', () => {
+    it('returns ApiOk envelope with attemptId, initialCwd, initialFs', async () => {
+      const mockData = {
+        attemptId: MOCK_ATTEMPT_ID,
+        initialCwd: '/home/dojo',
+        initialFs: { root: { type: 'dir' as const, name: '', children: [] } },
+      };
+      attemptsService.createAttempt.mockResolvedValue(mockData);
+
+      const result = await controller.createAttempt(MOCK_USER, { lessonId: 'ls-home' });
+
+      expect(result.ok).toBe(true);
+      expect(result.data).toBe(mockData);
+      expect('mission' in result.data).toBe(false);
+    });
+  });
+
+  describe('submitCommand', () => {
+    it('returns ApiOk envelope with command result', async () => {
+      const mockData = {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        cwdAfter: '/home/dojo',
+        attemptStatus: 'in_progress' as const,
+        validation: {
+          type: 'validation_failed' as const,
+          failedAtUtc: '',
+          failedCheckId: '',
+          reports: [],
+        },
+        trace: {
+          traceId: '',
+          inputLine: '',
+          parse: { ok: true },
+          resolve: { cwdBefore: '', resolvedPaths: [] },
+          execute: { exitCode: 0 },
+          validate: {
+            result: {
+              type: 'validation_failed' as const,
+              failedAtUtc: '',
+              failedCheckId: '',
+              reports: [],
+            },
+          },
+          budgets: {},
+        },
+        progressChanged: false,
+      };
+      attemptsService.submitCommand.mockResolvedValue(mockData as never);
+
+      const result = await controller.submitCommand(MOCK_USER, MOCK_ATTEMPT_ID, {
+        command: 'ls',
+        clientCommandId: 'uuid',
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.contractsVersion).toBeDefined();
+    });
+
+    it('propagates ForbiddenException for wrong owner', async () => {
+      attemptsService.submitCommand.mockRejectedValue(new ForbiddenException());
+      await expect(
+        controller.submitCommand(MOCK_USER, MOCK_ATTEMPT_ID, {
+          command: 'ls',
+          clientCommandId: 'uuid',
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('abandonAttempt', () => {
+    it('propagates ForbiddenException for wrong owner', async () => {
+      attemptsService.abandonAttempt.mockRejectedValue(new ForbiddenException());
+      await expect(controller.abandonAttempt(MOCK_USER, MOCK_ATTEMPT_ID)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('propagates ConflictException for non-in_progress attempt', async () => {
+      attemptsService.abandonAttempt.mockRejectedValue(new ConflictException());
+      await expect(controller.abandonAttempt(MOCK_USER, MOCK_ATTEMPT_ID)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+  });
+});

--- a/backend/src/attempts/attempts.controller.ts
+++ b/backend/src/attempts/attempts.controller.ts
@@ -2,13 +2,16 @@ import { Body, Controller, Get, Param, Patch, Post, UseGuards } from '@nestjs/co
 import {
   ApiBearerAuth,
   ApiConflictResponse,
+  ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiTags,
+  ApiUnprocessableEntityResponse,
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { buildOkResponse } from '../common/response.helper';
 import { AttemptsService } from './attempts.service';
 import { CreateAttemptDto } from './dto/create-attempt.dto';
 import { SubmitCommandDto } from './dto/submit-command.dto';
@@ -21,10 +24,12 @@ export class AttemptsController {
   constructor(private readonly attemptsService: AttemptsService) {}
 
   @Post()
-  @ApiOkResponse({ description: 'Creates a new in-progress attempt.' })
+  @ApiCreatedResponse({ description: 'Creates a new in-progress attempt.' })
+  @ApiNotFoundResponse({ description: 'Lesson not found.' })
+  @ApiUnprocessableEntityResponse({ description: 'Lesson exists but has no mission mapping.' })
   async createAttempt(@CurrentUser() user: { id: string }, @Body() dto: CreateAttemptDto) {
     const data = await this.attemptsService.createAttempt(user.id, dto);
-    return { ok: true, data };
+    return buildOkResponse(data);
   }
 
   @Get(':id')
@@ -33,7 +38,7 @@ export class AttemptsController {
   @ApiForbiddenResponse({ description: 'Attempt belongs to another user.' })
   async getAttempt(@CurrentUser() user: { id: string }, @Param('id') id: string) {
     const data = await this.attemptsService.getAttempt(user.id, id);
-    return { ok: true, data };
+    return buildOkResponse(data);
   }
 
   @Patch(':id/command')
@@ -46,7 +51,7 @@ export class AttemptsController {
     @Body() dto: SubmitCommandDto,
   ) {
     const data = await this.attemptsService.submitCommand(user.id, id, dto);
-    return { ok: true, data };
+    return buildOkResponse(data);
   }
 
   @Patch(':id/abandon')
@@ -55,6 +60,6 @@ export class AttemptsController {
   @ApiConflictResponse({ description: 'Attempt is already finished.' })
   async abandonAttempt(@CurrentUser() user: { id: string }, @Param('id') id: string) {
     const data = await this.attemptsService.abandonAttempt(user.id, id);
-    return { ok: true, data };
+    return buildOkResponse(data);
   }
 }

--- a/backend/src/attempts/attempts.module.ts
+++ b/backend/src/attempts/attempts.module.ts
@@ -4,10 +4,11 @@ import { AttemptsController } from './attempts.controller';
 import { AttemptsService } from './attempts.service';
 import { MissionsModule } from '../missions/missions.module';
 import { EngineModule } from '../engine/engine.module';
+import { LearningModule } from '../learning/learning.module';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 
 @Module({
-  imports: [JwtModule.register({}), MissionsModule, EngineModule],
+  imports: [JwtModule.register({}), MissionsModule, EngineModule, LearningModule],
   controllers: [AttemptsController],
   providers: [AttemptsService, JwtAuthGuard],
   exports: [AttemptsService],

--- a/backend/src/attempts/attempts.service.spec.ts
+++ b/backend/src/attempts/attempts.service.spec.ts
@@ -1,0 +1,119 @@
+import { NotFoundException, UnprocessableEntityException } from '@nestjs/common';
+import { AttemptsService } from './attempts.service';
+
+// Minimal stubs — controller unit specs mock the full service; this spec
+// targets service-level business logic only.
+
+const KNOWN_LESSON_ID = 'ls-home';
+const MAPPED_MISSION_ID = 'ch01-m03-list-home';
+const UNMAPPED_LESSON_ID = 'cat-mission'; // exists in learning content, not in the map
+
+const MOCK_MISSION = {
+  id: MAPPED_MISSION_ID,
+  version: 1,
+  chapterId: 'ch-01-basics',
+  title: 'List the home directory',
+  difficulty: 'easy' as const,
+  estimatedMinutes: 2,
+  shortDescription: 'Use ls.',
+  descriptionMd: 'Use ls.',
+  initialCwd: '/home/dojo',
+  initialFs: {
+    root: { type: 'dir' as const, name: '', children: [] },
+  },
+  checks: [],
+  hints: [],
+  allowedCommands: ['ls'],
+};
+
+const MOCK_ATTEMPT_ID = 'attempt-uuid-1234';
+
+function makeMockPrisma(overrides: Record<string, unknown> = {}) {
+  return {
+    attempt: {
+      create: jest.fn().mockResolvedValue({ id: MOCK_ATTEMPT_ID, ...overrides }),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    attemptStep: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  };
+}
+
+function makeMockMissions() {
+  return {
+    getMissionById: jest.fn((id: string) => {
+      if (id === MAPPED_MISSION_ID) return MOCK_MISSION;
+      throw new NotFoundException(`Mission not found: ${id}`);
+    }),
+  };
+}
+
+function makeMockEngine() {
+  return { run: jest.fn() };
+}
+
+function makeMockLearningContent() {
+  return {
+    getLessonById: jest.fn((id: string) => {
+      if (id === KNOWN_LESSON_ID || id === UNMAPPED_LESSON_ID) return { id };
+      throw new NotFoundException(`Lesson "${id}" was not found`);
+    }),
+  };
+}
+
+function makeService(prismaOverrides: Record<string, unknown> = {}) {
+  return new AttemptsService(
+    makeMockPrisma(prismaOverrides) as never,
+    makeMockMissions() as never,
+    makeMockEngine() as never,
+    makeMockLearningContent() as never,
+  );
+}
+
+describe('AttemptsService.createAttempt', () => {
+  it('resolves correct missionId for a known mapped lessonId', async () => {
+    const service = makeService();
+    const result = await service.createAttempt('user-1', { lessonId: KNOWN_LESSON_ID });
+
+    expect(result.attemptId).toBe(MOCK_ATTEMPT_ID);
+    expect(result.initialCwd).toBe('/home/dojo');
+    expect(result.initialFs).toBeDefined();
+    // mission field removed from public response
+    expect(result).not.toHaveProperty('mission');
+  });
+
+  it('throws 404 for a lessonId not in learning content', async () => {
+    const service = makeService();
+    await expect(service.createAttempt('user-1', { lessonId: 'no-such-lesson' })).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('throws 422 for a lessonId that exists but has no mission mapping', async () => {
+    const service = makeService();
+    await expect(service.createAttempt('user-1', { lessonId: UNMAPPED_LESSON_ID })).rejects.toThrow(
+      UnprocessableEntityException,
+    );
+  });
+
+  it('persists both lessonId and missionId on the created row', async () => {
+    const mockPrisma = makeMockPrisma();
+    mockPrisma.attempt.create.mockResolvedValue({ id: MOCK_ATTEMPT_ID });
+    const service = new AttemptsService(
+      mockPrisma as never,
+      makeMockMissions() as never,
+      makeMockEngine() as never,
+      makeMockLearningContent() as never,
+    );
+
+    await service.createAttempt('user-1', { lessonId: KNOWN_LESSON_ID });
+
+    const [callArg] = mockPrisma.attempt.create.mock.calls[0] as [{ data: Record<string, string> }];
+    expect(callArg.data.lessonId).toBe(KNOWN_LESSON_ID);
+    expect(callArg.data.missionId).toBe(MAPPED_MISSION_ID);
+  });
+});

--- a/backend/src/attempts/attempts.service.ts
+++ b/backend/src/attempts/attempts.service.ts
@@ -3,11 +3,14 @@ import {
   ForbiddenException,
   Injectable,
   NotFoundException,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { AttemptStep } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { MissionsService } from '../missions/missions.service';
 import { EngineService } from '../engine/engine.service';
+import { LearningContentService } from '../learning/learning-content.service';
+import { LESSON_MISSION_MAP } from '../learning-content/lesson-mission-mapping';
 import { ExecutionTrace, ValidationResult, VfsSnapshot } from '../engine/engine.types';
 import { CreateAttemptDto } from './dto/create-attempt.dto';
 import { SubmitCommandDto } from './dto/submit-command.dto';
@@ -20,14 +23,27 @@ export class AttemptsService {
     private readonly prisma: PrismaService,
     private readonly missions: MissionsService,
     private readonly engine: EngineService,
+    private readonly learningContent: LearningContentService,
   ) {}
 
   async createAttempt(userId: string, dto: CreateAttemptDto) {
-    const mission = this.missions.getMissionById(dto.missionId);
+    // Validate lesson exists in learning content (404 if not)
+    this.learningContent.getLessonById(dto.lessonId);
+
+    // Validate lesson has a mission mapping (422 if not — lesson exists but is not executable)
+    const missionId = LESSON_MISSION_MAP.get(dto.lessonId);
+    if (!missionId) {
+      throw new UnprocessableEntityException(
+        `Lesson "${dto.lessonId}" exists but has no mission mapping. It is display-only and cannot be started in this phase.`,
+      );
+    }
+
+    const mission = this.missions.getMissionById(missionId);
 
     const attempt = await this.prisma.attempt.create({
       data: {
         userId,
+        lessonId: dto.lessonId,
         missionId: mission.id,
         missionVersion: mission.version,
         status: 'in_progress' satisfies AttemptStatus,
@@ -41,16 +57,6 @@ export class AttemptsService {
       attemptId: attempt.id,
       initialCwd: mission.initialCwd,
       initialFs: mission.initialFs,
-      mission: {
-        id: mission.id,
-        version: mission.version,
-        chapterId: mission.chapterId,
-        title: mission.title,
-        difficulty: mission.difficulty,
-        estimatedMinutes: mission.estimatedMinutes,
-        shortDescription: mission.shortDescription,
-        ...(mission.tags ? { tags: mission.tags } : {}),
-      },
     };
   }
 
@@ -82,9 +88,9 @@ export class AttemptsService {
   async submitCommand(userId: string, attemptId: string, dto: SubmitCommandDto) {
     const attempt = await this.getOwnedAttemptOrThrow(userId, attemptId);
 
-    this.assertAttemptInProgress(attempt.status as AttemptStatus, 'submit more commands');
-
-    // Idempotency: if this clientCommandId was already recorded, return its result
+    // Idempotency check runs before the status guard so that re-submitting the
+    // completing command after the attempt is already 'completed' returns the
+    // cached result rather than 409.
     const existing = await this.prisma.attemptStep.findUnique({
       where: {
         attemptId_clientCommandId: {
@@ -106,6 +112,8 @@ export class AttemptsService {
         progressChanged: false,
       };
     }
+
+    this.assertAttemptInProgress(attempt.status as AttemptStatus, 'submit more commands');
 
     // Load current VFS + mission checks
     const mission = this.missions.getMissionById(attempt.missionId);

--- a/backend/src/attempts/dto/create-attempt.dto.ts
+++ b/backend/src/attempts/dto/create-attempt.dto.ts
@@ -2,8 +2,8 @@ import { IsString, MinLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateAttemptDto {
-  @ApiProperty({ description: 'The mission to attempt.' })
+  @ApiProperty({ description: 'The lesson to start. Must exist in the learning content.' })
   @IsString()
   @MinLength(1)
-  missionId!: string;
+  lessonId!: string;
 }

--- a/backend/src/common/response.helper.spec.ts
+++ b/backend/src/common/response.helper.spec.ts
@@ -1,0 +1,20 @@
+import { buildOkResponse, CONTRACTS_VERSION } from './response.helper';
+
+describe('buildOkResponse', () => {
+  it('sets ok: true, contractsVersion, and a valid ISO serverTimeUtc', () => {
+    const data = { foo: 'bar' };
+    const response = buildOkResponse(data);
+
+    expect(response.ok).toBe(true);
+    expect(response.contractsVersion).toBe(CONTRACTS_VERSION);
+    expect(typeof response.serverTimeUtc).toBe('string');
+    expect(() => new Date(response.serverTimeUtc)).not.toThrow();
+    expect(new Date(response.serverTimeUtc).toISOString()).toBe(response.serverTimeUtc);
+    expect(response.data).toBe(data);
+  });
+
+  it('forwards the data payload without modification', () => {
+    const data = { nested: { value: 42 } };
+    expect(buildOkResponse(data).data).toBe(data);
+  });
+});

--- a/backend/src/common/response.helper.ts
+++ b/backend/src/common/response.helper.ts
@@ -1,0 +1,18 @@
+export const CONTRACTS_VERSION = '0.2.0' as const;
+export type ContractsVersion = typeof CONTRACTS_VERSION;
+
+export type ApiOkResponse<T> = {
+  ok: true;
+  contractsVersion: ContractsVersion;
+  serverTimeUtc: string;
+  data: T;
+};
+
+export function buildOkResponse<T>(data: T): ApiOkResponse<T> {
+  return {
+    ok: true,
+    contractsVersion: CONTRACTS_VERSION,
+    serverTimeUtc: new Date().toISOString(),
+    data,
+  };
+}

--- a/backend/src/learning-content/lesson-mission-mapping.ts
+++ b/backend/src/learning-content/lesson-mission-mapping.ts
@@ -1,0 +1,57 @@
+// E2E test constants — update these when the mapping changes:
+//   E2E_LESSON_ID = 'ls-home'
+//   E2E_COMPLETION_COMMANDS = ['ls']
+//
+// The mapped mission (ch01-m03-list-home) starts with /home/dojo/projects/ in the
+// initial VFS. Running `ls` from /home/dojo produces "projects" on stdout, which
+// satisfies the output_contains check.
+
+/**
+ * Authoritative ordered list of [lessonId, missionId] pairs.
+ *
+ * Stored as an array of tuples (not a plain object) so that runtime duplicate-key
+ * detection is possible — object literals silently collapse duplicate keys before
+ * any validator can inspect them.
+ */
+export const LESSON_MISSION_ENTRIES: ReadonlyArray<readonly [string, string]> = [
+  ['ls-home', 'ch01-m03-list-home'],
+] as const;
+
+/**
+ * Derived map for O(1) lookups by lessonId.
+ * Built from LESSON_MISSION_ENTRIES at module load time.
+ */
+export const LESSON_MISSION_MAP: ReadonlyMap<string, string> = new Map(LESSON_MISSION_ENTRIES);
+
+/**
+ * Validates the mapping entries against the known lesson and mission ID sets.
+ * Called once at application startup. Throws with a descriptive error on any violation.
+ */
+export function validateLessonMissionMapping(
+  entries: ReadonlyArray<readonly [string, string]>,
+  knownLessonIds: ReadonlySet<string>,
+  knownMissionIds: ReadonlySet<string>,
+): void {
+  const seenLessonIds = new Set<string>();
+
+  for (const [lessonId, missionId] of entries) {
+    if (seenLessonIds.has(lessonId)) {
+      throw new Error(
+        `Duplicate lessonId in LESSON_MISSION_ENTRIES: "${lessonId}". Each lesson may appear at most once.`,
+      );
+    }
+    seenLessonIds.add(lessonId);
+
+    if (!knownLessonIds.has(lessonId)) {
+      throw new Error(
+        `LESSON_MISSION_ENTRIES references unknown lessonId: "${lessonId}". Add the lesson to learning content or remove this mapping entry.`,
+      );
+    }
+
+    if (!knownMissionIds.has(missionId)) {
+      throw new Error(
+        `LESSON_MISSION_ENTRIES references unknown missionId: "${missionId}" (for lesson "${lessonId}"). Add the mission or fix the mapping entry.`,
+      );
+    }
+  }
+}

--- a/backend/src/learning/learning-content.loader.spec.ts
+++ b/backend/src/learning/learning-content.loader.spec.ts
@@ -1,5 +1,6 @@
 import { learningContentSource } from '../learning-content/learning-content.registry';
 import { LearningContentSource } from '../learning-content/learning-content.types';
+import { validateLessonMissionMapping } from '../learning-content/lesson-mission-mapping';
 import { loadLearningContent } from './learning-content.loader';
 
 describe('loadLearningContent', () => {
@@ -47,5 +48,45 @@ describe('loadLearningContent', () => {
     source.lessons[0].order = 99;
 
     expect(() => loadLearningContent(source)).toThrow(/sequential/i);
+  });
+});
+
+describe('validateLessonMissionMapping', () => {
+  const knownLessons = new Set(['lesson-a', 'lesson-b']);
+  const knownMissions = new Set(['mission-x', 'mission-y']);
+
+  it('passes for valid entries', () => {
+    expect(() =>
+      validateLessonMissionMapping([['lesson-a', 'mission-x']], knownLessons, knownMissions),
+    ).not.toThrow();
+  });
+
+  it('passes for an empty entries array', () => {
+    expect(() => validateLessonMissionMapping([], knownLessons, knownMissions)).not.toThrow();
+  });
+
+  it('throws for an entry with an unknown lessonId', () => {
+    expect(() =>
+      validateLessonMissionMapping([['unknown-lesson', 'mission-x']], knownLessons, knownMissions),
+    ).toThrow(/unknown lessonId.*unknown-lesson/i);
+  });
+
+  it('throws for an entry with an unknown missionId', () => {
+    expect(() =>
+      validateLessonMissionMapping([['lesson-a', 'unknown-mission']], knownLessons, knownMissions),
+    ).toThrow(/unknown missionId.*unknown-mission/i);
+  });
+
+  it('throws for duplicate lessonId in entries', () => {
+    expect(() =>
+      validateLessonMissionMapping(
+        [
+          ['lesson-a', 'mission-x'],
+          ['lesson-a', 'mission-y'],
+        ],
+        knownLessons,
+        knownMissions,
+      ),
+    ).toThrow(/duplicate lessonId.*lesson-a/i);
   });
 });

--- a/backend/src/learning/learning-content.service.ts
+++ b/backend/src/learning/learning-content.service.ts
@@ -4,11 +4,24 @@ import {
   LearningOverviewResponse,
 } from '../learning-content/learning-content.types';
 import { learningContentSource } from '../learning-content/learning-content.registry';
+import {
+  LESSON_MISSION_ENTRIES,
+  validateLessonMissionMapping,
+} from '../learning-content/lesson-mission-mapping';
+import { missionContentSource } from '../missions-content/missions-content.registry';
+import { loadMissionsContent } from '../missions-content/missions-content.loader';
 import { loadLearningContent } from './learning-content.loader';
 
 @Injectable()
 export class LearningContentService {
   private readonly loadedContent = loadLearningContent(learningContentSource);
+
+  constructor() {
+    const knownLessonIds = new Set(this.loadedContent.lessonDetailsById.keys());
+    const loadedMissions = loadMissionsContent(missionContentSource);
+    const knownMissionIds = new Set(loadedMissions.missionById.keys());
+    validateLessonMissionMapping(LESSON_MISSION_ENTRIES, knownLessonIds, knownMissionIds);
+  }
 
   getOverview(): LearningOverviewResponse {
     return this.loadedContent.overview;
@@ -21,5 +34,9 @@ export class LearningContentService {
     }
 
     return { lesson };
+  }
+
+  getLessonIds(): ReadonlySet<string> {
+    return new Set(this.loadedContent.lessonDetailsById.keys());
   }
 }

--- a/backend/src/learning/learning-overview.service.spec.ts
+++ b/backend/src/learning/learning-overview.service.spec.ts
@@ -1,0 +1,198 @@
+// Control LESSON_MISSION_MAP and LESSON_MISSION_ENTRIES for all tests in this file.
+// lesson-a and lesson-b are startable; lesson-preview is intentionally absent
+// so P1 (non-startable skip) tests can use it without adjusting the mock.
+jest.mock('../learning-content/lesson-mission-mapping', () => ({
+  LESSON_MISSION_ENTRIES: [
+    ['lesson-a', 'mission-x'],
+    ['lesson-b', 'mission-y'],
+  ] as const,
+  LESSON_MISSION_MAP: new Map([
+    ['lesson-a', 'mission-x'],
+    ['lesson-b', 'mission-y'],
+  ]),
+}));
+
+import { LearningOverviewService } from './learning-overview.service';
+import { LearningOverviewResponse } from '../learning-content/learning-content.types';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+/** Two-lesson curriculum — both lessons are startable per the mock above. */
+const STATIC_OVERVIEW: LearningOverviewResponse = {
+  modules: [
+    {
+      id: 'mod-1',
+      slug: 'mod-1',
+      title: 'Module 1',
+      description: 'First module',
+      order: 1,
+      lessons: [
+        { id: 'lesson-a', slug: 'lesson-a', title: 'Lesson A', order: 1, status: 'active' },
+        { id: 'lesson-b', slug: 'lesson-b', title: 'Lesson B', order: 2, status: 'locked' },
+      ],
+    },
+  ],
+};
+
+/**
+ * Three-lesson curriculum where the middle lesson has no mission mapping.
+ * Used to verify that non-startable lessons are skipped when choosing active.
+ */
+const THREE_LESSON_OVERVIEW: LearningOverviewResponse = {
+  modules: [
+    {
+      id: 'mod-1',
+      slug: 'mod-1',
+      title: 'Module 1',
+      description: 'First module',
+      order: 1,
+      lessons: [
+        { id: 'lesson-a', slug: 'lesson-a', title: 'Lesson A', order: 1, status: 'active' },
+        {
+          id: 'lesson-preview',
+          slug: 'lesson-preview',
+          title: 'Preview (no mission)',
+          order: 2,
+          status: 'locked',
+        },
+        { id: 'lesson-b', slug: 'lesson-b', title: 'Lesson B', order: 3, status: 'locked' },
+      ],
+    },
+  ],
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+type AttemptRow = { lessonId: string | null; missionId: string };
+
+function makeMockLearningContent(overview: LearningOverviewResponse = STATIC_OVERVIEW) {
+  return { getOverview: jest.fn().mockReturnValue(overview) };
+}
+
+function makeMockPrisma(rows: AttemptRow[] = []) {
+  return {
+    attempt: {
+      findMany: jest.fn().mockResolvedValue(rows),
+    },
+  };
+}
+
+function makeService(
+  rows: AttemptRow[] = [],
+  overview: LearningOverviewResponse = STATIC_OVERVIEW,
+) {
+  return new LearningOverviewService(
+    makeMockLearningContent(overview) as never,
+    makeMockPrisma(rows) as never,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('LearningOverviewService.getUserOverview', () => {
+  it('marks first startable lesson as active when no completed attempts', async () => {
+    const service = makeService([]);
+    const result = await service.getUserOverview('user-1');
+
+    const lessons = result.modules[0]?.lessons ?? [];
+    expect(lessons[0]?.status).toBe('active');
+    expect(lessons[1]?.status).toBe('locked');
+  });
+
+  it('marks completed lessons from attempt data and advances active to the next', async () => {
+    const service = makeService([{ lessonId: 'lesson-a', missionId: 'mission-x' }]);
+    const result = await service.getUserOverview('user-1');
+
+    const lessons = result.modules[0]?.lessons ?? [];
+    expect(lessons[0]?.status).toBe('completed');
+    expect(lessons[1]?.status).toBe('active');
+  });
+
+  it('produces exactly one active lesson in the sequential rule', async () => {
+    const service = makeService([]);
+    const result = await service.getUserOverview('user-1');
+
+    const allLessons = result.modules.flatMap((m) => m.lessons);
+    const activeCount = allLessons.filter((l) => l.status === 'active').length;
+    expect(activeCount).toBe(1);
+  });
+
+  it('returns all statuses as completed with no active lesson when all are done', async () => {
+    const service = makeService([
+      { lessonId: 'lesson-a', missionId: 'mission-x' },
+      { lessonId: 'lesson-b', missionId: 'mission-y' },
+    ]);
+    const result = await service.getUserOverview('user-1');
+
+    const lessons = result.modules[0]?.lessons ?? [];
+    expect(lessons.every((l) => l.status === 'completed')).toBe(true);
+
+    const allLessons = result.modules.flatMap((m) => m.lessons);
+    expect(allLessons.some((l) => l.status === 'active')).toBe(false);
+  });
+
+  // ── P1: skip non-startable (display-only) lessons when choosing active ─────
+
+  it('marks display-only lesson locked and promotes the next startable lesson to active', async () => {
+    // lesson-a done; lesson-preview has no mission mapping; lesson-b is next startable
+    const service = makeService(
+      [{ lessonId: 'lesson-a', missionId: 'mission-x' }],
+      THREE_LESSON_OVERVIEW,
+    );
+    const result = await service.getUserOverview('user-1');
+
+    const lessons = result.modules[0]?.lessons ?? [];
+    expect(lessons[0]?.status).toBe('completed'); // lesson-a
+    expect(lessons[1]?.status).toBe('locked'); // lesson-preview — no mission mapping
+    expect(lessons[2]?.status).toBe('active'); // lesson-b — skipped over preview
+  });
+
+  it('marks display-only lesson locked even when it is the first non-completed lesson', async () => {
+    // No completions; lesson-a is first and startable, so it is active.
+    // lesson-preview (non-startable) and lesson-b (after active) are both locked.
+    const service = makeService([], THREE_LESSON_OVERVIEW);
+    const result = await service.getUserOverview('user-1');
+
+    const lessons = result.modules[0]?.lessons ?? [];
+    expect(lessons[0]?.status).toBe('active'); // lesson-a
+    expect(lessons[1]?.status).toBe('locked'); // lesson-preview
+    expect(lessons[2]?.status).toBe('locked'); // lesson-b — after active
+  });
+
+  // ── P2: resolve legacy attempts via missionId reverse-lookup ──────────────
+
+  it('counts a legacy attempt (lessonId=null) via missionId reverse-lookup', async () => {
+    // mission-x reverse-maps to lesson-a in the mock above
+    const service = makeService([{ lessonId: null, missionId: 'mission-x' }]);
+    const result = await service.getUserOverview('user-1');
+
+    const lessons = result.modules[0]?.lessons ?? [];
+    expect(lessons[0]?.status).toBe('completed'); // lesson-a resolved from mission-x
+    expect(lessons[1]?.status).toBe('active'); // lesson-b advances
+  });
+
+  it('ignores legacy attempts whose missionId has no lesson mapping', async () => {
+    const service = makeService([
+      { lessonId: null, missionId: 'mission-unknown' },
+      { lessonId: null, missionId: 'mission-unknown' },
+    ]);
+    const result = await service.getUserOverview('user-1');
+
+    const lessons = result.modules[0]?.lessons ?? [];
+    expect(lessons[0]?.status).toBe('active');
+    expect(lessons[1]?.status).toBe('locked');
+  });
+
+  it('handles a mix of new-style and legacy completed attempts without double-counting', async () => {
+    // lesson-a via direct lessonId plus a redundant legacy row for the same lesson
+    const service = makeService([
+      { lessonId: 'lesson-a', missionId: 'mission-x' },
+      { lessonId: null, missionId: 'mission-x' },
+    ]);
+    const result = await service.getUserOverview('user-1');
+
+    const lessons = result.modules[0]?.lessons ?? [];
+    expect(lessons[0]?.status).toBe('completed');
+    expect(lessons[1]?.status).toBe('active');
+  });
+});

--- a/backend/src/learning/learning-overview.service.ts
+++ b/backend/src/learning/learning-overview.service.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { LearningContentService } from './learning-content.service';
+import {
+  LearningOverviewResponse,
+  LessonHeuristicStatus,
+} from '../learning-content/learning-content.types';
+import {
+  LESSON_MISSION_ENTRIES,
+  LESSON_MISSION_MAP,
+} from '../learning-content/lesson-mission-mapping';
+
+// Reverse lookup: missionId → lessonId. Used to resolve pre-migration Attempt
+// rows that have a null lessonId but a known missionId.
+const MISSION_TO_LESSON_MAP: ReadonlyMap<string, string> = new Map(
+  LESSON_MISSION_ENTRIES.map(([lessonId, missionId]) => [missionId, lessonId]),
+);
+
+@Injectable()
+export class LearningOverviewService {
+  constructor(
+    private readonly learningContent: LearningContentService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async getUserOverview(userId: string): Promise<LearningOverviewResponse> {
+    // Load static ordered curriculum
+    const staticOverview = this.learningContent.getOverview();
+
+    // Fetch ALL completed attempts for this user — do not filter by lessonId
+    // nullability. Legacy rows (written before the lessonId migration) have
+    // lessonId = null but carry missionId, which we resolve via the reverse map.
+    const completedAttempts = await this.prisma.attempt.findMany({
+      where: { userId, status: 'completed' },
+      select: { lessonId: true, missionId: true },
+    });
+
+    // Resolve lesson IDs for both new-style and legacy rows:
+    //   - new rows:    use lessonId directly
+    //   - legacy rows: fall back to MISSION_TO_LESSON_MAP lookup by missionId
+    const completedLessonIds = new Set(
+      completedAttempts
+        .map((a) => a.lessonId ?? MISSION_TO_LESSON_MAP.get(a.missionId))
+        .filter((id): id is string => id !== undefined),
+    );
+
+    // Sequential unlock rule:
+    //   - completed: user has at least one completed attempt for this lesson
+    //   - active:    first non-completed lesson that has a mission mapping
+    //                (display-only lessons without a mapping are always locked)
+    //   - locked:    all remaining lessons
+    let activeAssigned = false;
+    const modules = staticOverview.modules.map((module) => ({
+      ...module,
+      lessons: module.lessons.map((lesson) => {
+        let status: LessonHeuristicStatus;
+
+        if (completedLessonIds.has(lesson.id)) {
+          status = 'completed';
+        } else if (!activeAssigned && LESSON_MISSION_MAP.has(lesson.id)) {
+          status = 'active';
+          activeAssigned = true;
+        } else {
+          status = 'locked';
+        }
+
+        return { ...lesson, status };
+      }),
+    }));
+
+    return { modules };
+  }
+}

--- a/backend/src/learning/learning.controller.spec.ts
+++ b/backend/src/learning/learning.controller.spec.ts
@@ -1,0 +1,103 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { LearningController } from './learning.controller';
+import { LearningContentService } from './learning-content.service';
+import { LearningOverviewService } from './learning-overview.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+
+// Suppress unused variable warning for the guard import — it is used via overrideGuard
+void JwtAuthGuard;
+
+const MOCK_OVERVIEW = {
+  modules: [
+    {
+      id: 'mod-1',
+      slug: 'mod-1',
+      title: 'Module 1',
+      description: 'Desc',
+      order: 1,
+      lessons: [{ id: 'ls-home', slug: 'ls-home', title: 'List home', order: 1, status: 'active' }],
+    },
+  ],
+};
+
+const MOCK_LESSON_DETAIL = {
+  id: 'ls-home',
+  moduleId: 'mod-1',
+  slug: 'ls-home',
+  title: 'List home',
+  order: 1,
+  theoryMarkdown: 'Use ls.',
+  taskDescription: 'Run ls.',
+};
+
+describe('LearningController', () => {
+  let controller: LearningController;
+  let learningContentService: jest.Mocked<LearningContentService>;
+  let learningOverviewService: jest.Mocked<LearningOverviewService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LearningController],
+      providers: [
+        {
+          provide: LearningContentService,
+          useValue: {
+            getLessonById: jest.fn(),
+          },
+        },
+        {
+          provide: LearningOverviewService,
+          useValue: {
+            getUserOverview: jest.fn(),
+          },
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get(LearningController);
+    learningContentService = module.get(LearningContentService);
+    learningOverviewService = module.get(LearningOverviewService);
+  });
+
+  describe('getOverview', () => {
+    it('returns ApiOk envelope wrapping overview data', async () => {
+      learningOverviewService.getUserOverview.mockResolvedValue(MOCK_OVERVIEW);
+      const result = await controller.getOverview({ id: 'user-1' });
+
+      expect(result.ok).toBe(true);
+      expect(result.contractsVersion).toBeDefined();
+      expect(result.serverTimeUtc).toBeDefined();
+      expect(result.data).toBe(MOCK_OVERVIEW);
+    });
+
+    it('passes userId to getUserOverview', async () => {
+      learningOverviewService.getUserOverview.mockResolvedValue(MOCK_OVERVIEW);
+      await controller.getOverview({ id: 'user-abc' });
+      expect(learningOverviewService.getUserOverview.mock.calls[0]).toEqual(['user-abc']);
+    });
+  });
+
+  describe('getLessonById', () => {
+    it('returns ApiOk envelope with lesson detail — no missionId in response', () => {
+      learningContentService.getLessonById.mockReturnValue({ lesson: MOCK_LESSON_DETAIL });
+      const result = controller.getLessonById('ls-home');
+
+      expect(result.ok).toBe(true);
+      expect(result.data.lesson.id).toBe('ls-home');
+      // missionId must not leak into the lesson detail payload
+      expect('missionId' in result.data.lesson).toBe(false);
+    });
+
+    it('propagates NotFoundException for unknown lesson', () => {
+      learningContentService.getLessonById.mockImplementation(() => {
+        throw new NotFoundException('Lesson not found');
+      });
+
+      expect(() => controller.getLessonById('unknown')).toThrow(NotFoundException);
+    });
+  });
+});

--- a/backend/src/learning/learning.controller.ts
+++ b/backend/src/learning/learning.controller.ts
@@ -8,23 +8,30 @@ import {
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { buildOkResponse } from '../common/response.helper';
 import { LearningLessonDetailResponseDto } from './dto/learning-lesson-detail-response.dto';
 import { LearningOverviewResponseDto } from './dto/learning-overview-response.dto';
 import { LearningContentService } from './learning-content.service';
+import { LearningOverviewService } from './learning-overview.service';
 
 @ApiTags('Learning')
 @ApiBearerAuth('access-token')
 @UseGuards(JwtAuthGuard)
 @Controller()
 export class LearningController {
-  constructor(private readonly learningContentService: LearningContentService) {}
+  constructor(
+    private readonly learningContentService: LearningContentService,
+    private readonly learningOverviewService: LearningOverviewService,
+  ) {}
 
   @Get('learning/overview')
-  @ApiOperation({ summary: 'Get module and lesson overview for the curriculum' })
+  @ApiOperation({ summary: 'Get module and lesson overview with per-user lesson statuses' })
   @ApiOkResponse({ type: LearningOverviewResponseDto })
   @ApiUnauthorizedResponse({ description: 'Missing, invalid, or expired access token' })
-  getOverview() {
-    return this.learningContentService.getOverview();
+  async getOverview(@CurrentUser() user: { id: string }) {
+    const data = await this.learningOverviewService.getUserOverview(user.id);
+    return buildOkResponse(data);
   }
 
   @Get('lessons/:id')
@@ -33,6 +40,6 @@ export class LearningController {
   @ApiUnauthorizedResponse({ description: 'Missing, invalid, or expired access token' })
   @ApiNotFoundResponse({ description: 'Lesson was not found' })
   getLessonById(@Param('id') lessonId: string) {
-    return this.learningContentService.getLessonById(lessonId);
+    return buildOkResponse(this.learningContentService.getLessonById(lessonId));
   }
 }

--- a/backend/src/learning/learning.module.ts
+++ b/backend/src/learning/learning.module.ts
@@ -4,10 +4,12 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { UsersModule } from '../users/users.module';
 import { LearningController } from './learning.controller';
 import { LearningContentService } from './learning-content.service';
+import { LearningOverviewService } from './learning-overview.service';
 
 @Module({
   imports: [JwtModule.register({}), UsersModule],
   controllers: [LearningController],
-  providers: [LearningContentService, JwtAuthGuard],
+  providers: [LearningContentService, LearningOverviewService, JwtAuthGuard],
+  exports: [LearningContentService],
 })
 export class LearningModule {}

--- a/backend/src/missions-content/missions-content.registry.ts
+++ b/backend/src/missions-content/missions-content.registry.ts
@@ -4,7 +4,9 @@ import { MissionContentSource } from './missions-content.types';
 const ch01m01 = require('./missions/ch-01-basics/ch01-m01-print-cwd.mission.json') as unknown;
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const ch01m02 = require('./missions/ch-01-basics/ch01-m02-create-dirs.mission.json') as unknown;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const ch01m03 = require('./missions/ch-01-basics/ch01-m03-list-home.mission.json') as unknown;
 
 export const missionContentSource: MissionContentSource = {
-  missions: [ch01m01, ch01m02] as MissionContentSource['missions'],
+  missions: [ch01m01, ch01m02, ch01m03] as MissionContentSource['missions'],
 };

--- a/backend/src/missions-content/missions/ch-01-basics/ch01-m03-list-home.mission.json
+++ b/backend/src/missions-content/missions/ch-01-basics/ch01-m03-list-home.mission.json
@@ -1,0 +1,58 @@
+{
+  "id": "ch01-m03-list-home",
+  "version": 1,
+  "chapterId": "ch-01-basics",
+  "title": "List the home directory",
+  "difficulty": "easy",
+  "estimatedMinutes": 2,
+  "shortDescription": "Use ls to see what is in the home directory.",
+  "descriptionMd": "## What is here?\n\nThe `ls` command lists files and directories in your current location. By default you start in `/home/dojo`.\n\nRun `ls` to see the contents of the home directory.",
+  "goalMd": "Run `ls` successfully.",
+  "initialCwd": "/home/dojo",
+  "initialFs": {
+    "root": {
+      "type": "dir",
+      "name": "",
+      "children": [
+        {
+          "type": "dir",
+          "name": "home",
+          "children": [
+            {
+              "type": "dir",
+              "name": "dojo",
+              "children": [
+                {
+                  "type": "dir",
+                  "name": "projects",
+                  "children": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "checks": [
+    {
+      "id": "check-01",
+      "type": "exit_code_is",
+      "expectedExitCode": 0
+    },
+    {
+      "id": "check-02",
+      "type": "output_contains",
+      "stream": "stdout",
+      "text": "projects"
+    }
+  ],
+  "hints": [
+    {
+      "id": "hint-01",
+      "order": 1,
+      "textMd": "Type `ls` and press Enter."
+    }
+  ],
+  "allowedCommands": ["ls", "help"]
+}

--- a/docs/02-architecture/data-contracts.md
+++ b/docs/02-architecture/data-contracts.md
@@ -18,7 +18,7 @@ All API responses MUST include `contractsVersion`.
 - Breaking changes (rename/remove fields, meaning changes): bump **minor/major** + ADR
 
 ```ts
-export const CONTRACTS_VERSION = "0.1.0" as const;
+export const CONTRACTS_VERSION = "0.2.0" as const;
 export type ContractsVersion = typeof CONTRACTS_VERSION;
 ````
 
@@ -49,6 +49,7 @@ export type UserId = string;     // UUID v4
 export type MissionId = string;  // UUID v4 (or stable slug, but pick ONE)
 export type AttemptId = string;  // UUID v4
 export type TraceId = string;    // UUID v4
+export type LessonId = string;   // stable content slug (e.g. "ls-home")
 ```
 
 ### Paths
@@ -95,6 +96,8 @@ export type ApiErrorCode =
   | "validation_error"
   | "not_found"
   | "conflict"
+  | "forbidden"
+  | "not_executable"
   | "rate_limited"
   | "internal_error";
 ```
@@ -516,6 +519,48 @@ export type TraceEffect =
 Attempts are owned by authenticated users (JWT). The backend is the authoritative owner of
 attempt state — `cwd`, VFS snapshot, status, and the immutable step log.
 
+### Lesson status
+
+```ts
+export type LessonStatus = "locked" | "active" | "completed";
+```
+
+### Lesson and module summary (learning overview)
+
+```ts
+export type LessonSummary = {
+  id: LessonId;
+  slug: string;
+  title: string;
+  order: number;
+  status: LessonStatus;
+};
+
+export type ModuleSummary = {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  order: number;
+  lessons: LessonSummary[];
+};
+```
+
+### Lesson detail (full lesson content)
+
+```ts
+export type LessonDetail = {
+  id: LessonId;
+  moduleId: string;
+  slug: string;
+  title: string;
+  order: number;
+  theoryMarkdown: string;
+  taskDescription: string;
+  hints?: string[];
+};
+```
+
 ### Attempt status
 
 ```ts
@@ -591,6 +636,27 @@ export type ProgressSnapshot = {
 
 ## 10) Backend endpoints (contracts)
 
+### `GET /api/learning/overview`
+
+Returns ordered modules with per-user lesson statuses. Requires authentication (JWT).
+
+```ts
+export type GetLearningOverviewResponse = ApiOk<{
+  modules: ModuleSummary[];
+}>;
+```
+
+### `GET /api/lessons/:id`
+
+Returns full lesson content by lesson ID. Requires authentication (JWT).
+Returns 404 if the lesson is unknown.
+
+```ts
+export type GetLessonByIdResponse = ApiOk<{
+  lesson: LessonDetail;
+}>;
+```
+
 ### `GET /api/version`
 
 ```ts
@@ -623,16 +689,18 @@ export type GetMissionByIdResponse = ApiOk<{
 
 Create a new in-progress attempt. Requires authentication (JWT).
 
+Returns 404 if the lesson is unknown. Returns 422 if the lesson exists but has no
+mission mapping (display-only, not executable in this phase).
+
 ```ts
 export type PostAttemptsRequest = {
-  missionId: MissionId;
+  lessonId: LessonId;
 };
 
 export type PostAttemptsResponse = ApiOk<{
   attemptId: AttemptId;
   initialCwd: PosixPath;
   initialFs: VfsSnapshot;
-  mission: MissionHeader;
 }>;
 ```
 


### PR DESCRIPTION
## Goal
Establish the data foundation for the lesson-centric API rewrite: updated shared contracts, new `ls-home` mission, and the lesson-to-mission mapping file with startup validation.

**Part 1 of 3** — Prisma schema migration and runtime logic follow in #96.

## Changes
- `docs/02-architecture/data-contracts.md` — bump `CONTRACTS_VERSION` to `0.2.0`; add `LessonId`, `LessonStatus`, `LessonSummary`, `ModuleSummary`, `LessonDetail`; update `PostAttemptsRequest` to `{ lessonId }`; remove `mission` from `PostAttemptsResponse`; add `GetLearningOverviewResponse`, `GetLessonByIdResponse`; add `"forbidden"` and `"not_executable"` to `ApiErrorCode`
- `backend/src/learning-content/lesson-mission-mapping.ts` — SSOT for lesson→mission pairs; exports `LESSON_MISSION_ENTRIES` and `LESSON_MISSION_MAP`; startup validation via `validateLessonMissionMapping()`
- `backend/src/learning/learning-content.service.ts` — add `getLessonIds()` and call `validateLessonMissionMapping()` in constructor
- `backend/src/missions-content/missions/ch-01-basics/ch01-m03-list-home.mission.json` — new mission mapped to `ls-home` lesson; checks `ls` produces `"projects"` on stdout
- `backend/src/learning/learning-content.loader.spec.ts` — unit tests for mapping validation (unknown lessonId, unknown missionId, duplicate key, empty mapping)

## How to test
```bash
cd backend
npm test       # all unit tests pass (105 tests)
npm run build  # nest build clean
```

## Screenshots/GIF
n/a

## Docs/Contracts updated
- `docs/02-architecture/data-contracts.md` — version bumped to 0.2.0

## Risks
- `CONTRACTS_VERSION` bump is a breaking change; frontend must be updated in a coordinated PR once all 3 parts are merged
- **No Prisma migration in this PR** — schema column and writer land together in #96 to avoid a deployment window where new attempts accumulate `lessonId = NULL`