### PR TITLE
Fix improve terminal input and lesson library interactions.

### DIFF
--- a/frontend/src/ui/components/ModulesSidebar.test.tsx
+++ b/frontend/src/ui/components/ModulesSidebar.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { LearningModule } from '@/features/learning/types';
+
+import { ModulesSidebar } from './ModulesSidebar';
+
+type StoreState = {
+  modules: LearningModule[];
+  expandedModuleId: string | null;
+  activeLessonId: string | null;
+  setActiveLesson: ReturnType<typeof vi.fn>;
+  setExpandedModuleId: ReturnType<typeof vi.fn>;
+  initialize: ReturnType<typeof vi.fn>;
+  isBootstrapping: boolean;
+};
+
+const storeState: StoreState = {
+  modules: [],
+  expandedModuleId: null,
+  activeLessonId: null,
+  setActiveLesson: vi.fn(),
+  setExpandedModuleId: vi.fn(),
+  initialize: vi.fn().mockResolvedValue(undefined),
+  isBootstrapping: false,
+};
+
+vi.mock('@/store/terminalSession', () => ({
+  useTerminalSession: (selector: (state: StoreState) => unknown) => selector(storeState),
+}));
+
+const modulesFixture: LearningModule[] = [
+  {
+    id: 'cmd-basics',
+    slug: 'cmd-basics',
+    title: 'Command Line Basics',
+    description: 'Core shell basics',
+    order: 1,
+    lessons: [
+      {
+        id: 'lesson-1',
+        slug: 'lesson-1',
+        title: 'List files',
+        order: 1,
+        status: 'active',
+      },
+    ],
+  },
+];
+
+describe('ModulesSidebar', () => {
+  beforeEach(() => {
+    storeState.modules = modulesFixture;
+    storeState.expandedModuleId = 'cmd-basics';
+    storeState.activeLessonId = 'lesson-1';
+    storeState.setActiveLesson = vi.fn();
+    storeState.setExpandedModuleId = vi.fn();
+    storeState.initialize = vi.fn().mockResolvedValue(undefined);
+    storeState.isBootstrapping = false;
+  });
+
+  it('collapses an open module on the first click without logging React warnings', async () => {
+    const user = userEvent.setup();
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<ModulesSidebar />);
+
+    await user.click(screen.getByRole('button', { name: /command line basics/i }));
+
+    expect(storeState.setExpandedModuleId).toHaveBeenCalledWith(null);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/frontend/src/ui/components/ModulesSidebar.tsx
+++ b/frontend/src/ui/components/ModulesSidebar.tsx
@@ -47,7 +47,7 @@ export function ModulesSidebar() {
       <Accordion
         type="single"
         collapsible
-        value={openId ?? undefined}
+        value={openId ?? ''}
         onValueChange={(val) => setExpandedModuleId(val || null)}
         className="space-y-3"
       >

--- a/frontend/src/ui/components/TerminalWindow.test.tsx
+++ b/frontend/src/ui/components/TerminalWindow.test.tsx
@@ -1,0 +1,90 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const terminalSessionMocks = vi.hoisted(() => ({
+  output: [],
+  cwd: '/home/student',
+  runCommand: vi.fn(),
+  history: [],
+  isTerminalBusy: false,
+}));
+
+const terminalHarness = vi.hoisted(() => {
+  let onDataHandler: ((data: string) => void) | null = null;
+
+  class MockTerminal {
+    write = vi.fn();
+    writeln = vi.fn();
+    open = vi.fn();
+    loadAddon = vi.fn();
+    focus = vi.fn();
+    clear = vi.fn();
+    dispose = vi.fn();
+
+    onData(handler: (data: string) => void) {
+      onDataHandler = handler;
+      return {
+        dispose: vi.fn(() => {
+          onDataHandler = null;
+        }),
+      };
+    }
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+  }
+
+  return {
+    MockTerminal,
+    MockFitAddon,
+    emitData(data: string) {
+      onDataHandler?.(data);
+    },
+    reset() {
+      onDataHandler = null;
+    },
+  };
+});
+
+vi.mock('xterm', () => ({
+  Terminal: terminalHarness.MockTerminal,
+}));
+
+vi.mock('xterm-addon-fit', () => ({
+  FitAddon: terminalHarness.MockFitAddon,
+}));
+
+vi.mock('xterm/css/xterm.css', () => ({}));
+
+vi.mock('@/store/terminalSession', () => ({
+  useTerminalSession: (selector: (state: typeof terminalSessionMocks) => unknown) =>
+    selector(terminalSessionMocks),
+}));
+
+import { TerminalWindow } from './TerminalWindow';
+
+describe('TerminalWindow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    terminalHarness.reset();
+    terminalSessionMocks.output = [];
+    terminalSessionMocks.cwd = '/home/student';
+    terminalSessionMocks.history = [];
+    terminalSessionMocks.isTerminalBusy = false;
+  });
+
+  it('supports moving the cursor left and right within the current command', () => {
+    render(<TerminalWindow />);
+
+    terminalHarness.emitData('a');
+    terminalHarness.emitData('c');
+    terminalHarness.emitData('\u001b[D');
+    terminalHarness.emitData('b');
+    terminalHarness.emitData('\u001b[C');
+    terminalHarness.emitData('d');
+    terminalHarness.emitData('\r');
+
+    expect(terminalSessionMocks.runCommand).toHaveBeenCalledWith('abcd');
+  });
+});

--- a/frontend/src/ui/components/TerminalWindow.tsx
+++ b/frontend/src/ui/components/TerminalWindow.tsx
@@ -40,6 +40,7 @@ export function TerminalWindow({ height, className }: Props) {
   const termRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const inputRef = useRef('');
+  const cursorIndexRef = useRef(0);
   const historyIndexRef = useRef<number | null>(null);
   const historyRef = useRef<string[]>(history);
   const runCommandRef = useRef(runCommand);
@@ -67,6 +68,10 @@ export function TerminalWindow({ height, className }: Props) {
     term.write('\r');
     term.write('\u001b[2K');
     term.write(`${promptRef.current}${inputRef.current}`);
+    const moveLeft = inputRef.current.length - cursorIndexRef.current;
+    if (moveLeft > 0) {
+      term.write(`\u001b[${moveLeft}D`);
+    }
   }, [prompt]);
 
   useEffect(() => {
@@ -119,13 +124,16 @@ export function TerminalWindow({ height, className }: Props) {
       term.write('\r');
       term.write('\u001b[2K');
       term.write(`${promptRef.current}${inputRef.current}`);
+      const moveLeft = inputRef.current.length - cursorIndexRef.current;
+      if (moveLeft > 0) {
+        term.write(`\u001b[${moveLeft}D`);
+      }
     };
 
     const applyInput = (value: string) => {
       inputRef.current = value;
-      term.write('\r');
-      term.write('\u001b[2K');
-      term.write(`${promptRef.current}${value}`);
+      cursorIndexRef.current = value.length;
+      renderPrompt();
     };
 
     const handleHistory = (direction: 'up' | 'down') => {
@@ -160,6 +168,7 @@ export function TerminalWindow({ height, className }: Props) {
       if (data === '\u0003') {
         term.writeln('^C');
         inputRef.current = '';
+        cursorIndexRef.current = 0;
         historyIndexRef.current = null;
         renderPrompt();
         return;
@@ -170,6 +179,7 @@ export function TerminalWindow({ height, className }: Props) {
         term.writeln('');
         historyIndexRef.current = null;
         inputRef.current = '';
+        cursorIndexRef.current = 0;
         if (raw.trim().length > 0) {
           lastSubmittedCommandRef.current = raw;
           void runCommandRef.current(raw);
@@ -180,9 +190,13 @@ export function TerminalWindow({ height, className }: Props) {
       }
 
       if (data === '\u007f') {
-        if (inputRef.current.length > 0) {
-          inputRef.current = inputRef.current.slice(0, -1);
-          term.write('\b \b');
+        if (cursorIndexRef.current > 0) {
+          const value = inputRef.current;
+          const nextCursorIndex = cursorIndexRef.current - 1;
+          inputRef.current =
+            value.slice(0, nextCursorIndex) + value.slice(cursorIndexRef.current);
+          cursorIndexRef.current = nextCursorIndex;
+          renderPrompt();
         }
         return;
       }
@@ -195,13 +209,31 @@ export function TerminalWindow({ height, className }: Props) {
         handleHistory('down');
         return;
       }
+      if (data === '\u001b[D') {
+        if (cursorIndexRef.current > 0) {
+          cursorIndexRef.current -= 1;
+          term.write('\u001b[D');
+        }
+        return;
+      }
+      if (data === '\u001b[C') {
+        if (cursorIndexRef.current < inputRef.current.length) {
+          cursorIndexRef.current += 1;
+          term.write('\u001b[C');
+        }
+        return;
+      }
 
       if (data.startsWith('\u001b')) {
         return;
       }
 
-      inputRef.current += data;
-      term.write(data);
+      const value = inputRef.current;
+      const cursorIndex = cursorIndexRef.current;
+      inputRef.current =
+        value.slice(0, cursorIndex) + data + value.slice(cursorIndex);
+      cursorIndexRef.current = cursorIndex + data.length;
+      renderPrompt();
     };
 
     const dataDisposable = term.onData(handleData);
@@ -225,6 +257,7 @@ export function TerminalWindow({ height, className }: Props) {
       term.clear();
       lastOutputIndexRef.current = 0;
       inputRef.current = '';
+      cursorIndexRef.current = 0;
       historyIndexRef.current = null;
       lastSubmittedCommandRef.current = null;
     }
@@ -251,6 +284,10 @@ export function TerminalWindow({ height, className }: Props) {
     term.write('\r');
     term.write('\u001b[2K');
     term.write(`${promptRef.current}${inputRef.current}`);
+    const moveLeft = inputRef.current.length - cursorIndexRef.current;
+    if (moveLeft > 0) {
+      term.write(`\u001b[${moveLeft}D`);
+    }
   }, [output]);
 
   useEffect(() => {

--- a/frontend/src/ui/components/TerminalWindow.tsx
+++ b/frontend/src/ui/components/TerminalWindow.tsx
@@ -230,8 +230,7 @@ export function TerminalWindow({ height, className }: Props) {
 
       const value = inputRef.current;
       const cursorIndex = cursorIndexRef.current;
-      inputRef.current =
-        value.slice(0, cursorIndex) + data + value.slice(cursorIndex);
+      inputRef.current = value.slice(0, cursorIndex) + data + value.slice(cursorIndex);
       cursorIndexRef.current = cursorIndex + data.length;
       renderPrompt();
     };

--- a/frontend/src/ui/screens/library/sections/LibraryLessonDetails.test.tsx
+++ b/frontend/src/ui/screens/library/sections/LibraryLessonDetails.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { LibraryLessonDetails } from './LibraryLessonDetails';
@@ -38,5 +39,32 @@ describe('LibraryLessonDetails', () => {
     expect(screen.getByRole('heading', { name: 'List files' })).toBeInTheDocument();
     expect(screen.getAllByText('—')).toHaveLength(2);
     expect(screen.getByText('0/3 steps')).toBeInTheDocument();
+  });
+
+  it('keeps hints hidden until the spoiler is expanded', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <LibraryLessonDetails
+        moduleTitle="Command Line Basics"
+        progress={{ completed: 1, total: 3 }}
+        lesson={{
+          id: 'lesson-2',
+          slug: 'lesson-2',
+          title: 'Read a file',
+          order: 2,
+          status: 'active',
+          theoryMarkdown: 'Use cat to print file content.',
+          taskDescription: 'Read mission.txt.',
+          hints: ['Try the cat command.'],
+        }}
+      />,
+    );
+
+    expect(screen.queryByText('Try the cat command.')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Hints' }));
+
+    expect(screen.getByText('Try the cat command.')).toBeInTheDocument();
   });
 });

--- a/frontend/src/ui/screens/library/sections/LibraryLessonDetails.tsx
+++ b/frontend/src/ui/screens/library/sections/LibraryLessonDetails.tsx
@@ -1,3 +1,5 @@
+import { useId, useState } from 'react';
+
 import { type LearningLessonView } from '@/features/learning/types';
 import { useI18n } from '@/i18n/useI18n';
 import { AchievementStars } from '@/ui/components/AchievementStars';
@@ -18,9 +20,11 @@ export function LibraryLessonDetails({
   progress,
 }: LibraryLessonDetailsProps) {
   const { t } = useI18n();
+  const [areHintsVisible, setAreHintsVisible] = useState(false);
   const theoryTitleId = 'library-lesson-theory-title';
   const taskTitleId = 'library-lesson-task-title';
   const hintsTitleId = 'library-lesson-hints-title';
+  const hintsContentId = useId();
 
   return (
     <section
@@ -79,11 +83,27 @@ export function LibraryLessonDetails({
             <h3 id={hintsTitleId} className="font-semibold text-yellow-100">
               {t('library.hints')}
             </h3>
-            <ul className="space-y-1 text-yellow-100/80">
-              {lesson.hints.map((hint) => (
-                <li key={hint}>{hint}</li>
-              ))}
-            </ul>
+            <div className="rounded-md border border-yellow-400/20 bg-white/5">
+              <button
+                type="button"
+                aria-expanded={areHintsVisible}
+                aria-controls={hintsContentId}
+                onClick={() => setAreHintsVisible((current) => !current)}
+                className="w-full cursor-pointer px-3 py-2 text-left text-sm font-medium text-yellow-100"
+              >
+                {t('library.hints')}
+              </button>
+              {areHintsVisible ? (
+                <ul
+                  id={hintsContentId}
+                  className="space-y-1 border-t border-yellow-400/15 px-3 py-3 text-yellow-100/80"
+                >
+                  {lesson.hints.map((hint) => (
+                    <li key={hint}>{hint}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
## Summary
This PR fixes three frontend issues found during task flow testing:

- added proper left/right arrow cursor movement in the terminal input
- fixed the controlled accordion state so an expanded module collapses correctly on the first click
- hid lesson hints behind a spoiler instead of showing them immediately

## Details
Terminal input now tracks cursor position and supports editing inside the current command, not only at the end of the line.

The modules accordion no longer switches between controlled and uncontrolled modes, which removes the console warning and restores expected click behavior.

Lesson hints are now hidden by default and shown only after explicit user interaction.