### PR TITLE
feat(backend): enable CORS and HTTPS for production deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,8 @@ backend/uploads/
 **/.env
 **/.env.*
 !**/.env.example
+# Production env bakes in the public EC2 API URL — no secrets, safe to commit
+!frontend/.env.production
 
 # =========================
 # OS

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,10 @@
 DATABASE_URL="file:./dev.db"
 OPENROUTER_API_KEY=your_openrouter_api_key
 OPENROUTER_MODEL=openrouter/free
+
+# Allowed cross-origin for the browser CORS policy.
+# Set to the exact frontend origin in production (e.g. https://your-org.github.io).
+# Single origin only — no wildcards, no comma-separated values.
+# Leave empty in development: the Vite dev proxy serves requests same-origin,
+# so CORS headers are never needed locally.
+CORS_ORIGIN=

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -39,6 +39,14 @@ async function bootstrap() {
     },
   });
 
+  app.enableCors({
+    // Array form compares request Origin against the list — only matching origins
+    // receive the header. Undefined in dev is intentional: the Vite proxy serves
+    // all requests same-origin, so CORS headers are never requested.
+    origin: process.env.CORS_ORIGIN ? [process.env.CORS_ORIGIN] : undefined,
+    credentials: true,
+  });
+
   await app.listen(process.env.PORT ?? 3001);
 }
 void bootstrap();

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -39,12 +39,17 @@ async function bootstrap() {
     },
   });
 
+  // Normalize to scheme+host only — strips accidental trailing slash or path.
+  // Throws at startup if CORS_ORIGIN is set but malformed (fail-fast).
+  const corsOrigin = process.env.CORS_ORIGIN ? new URL(process.env.CORS_ORIGIN).origin : undefined;
+
   app.enableCors({
     // Array form compares request Origin against the list — only matching origins
     // receive the header. Undefined in dev is intentional: the Vite proxy serves
     // all requests same-origin, so CORS headers are never requested.
-    origin: process.env.CORS_ORIGIN ? [process.env.CORS_ORIGIN] : undefined,
-    credentials: true,
+    origin: corsOrigin ? [corsOrigin] : undefined,
+    // credentials: true omitted — JWT is sent via Authorization header, not cookies.
+    // Omitting this prevents inadvertent cross-origin cookie access.
   });
 
   await app.listen(process.env.PORT ?? 3001);

--- a/backend/test/cors.e2e-spec.ts
+++ b/backend/test/cors.e2e-spec.ts
@@ -1,0 +1,71 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { App } from 'supertest/types';
+
+import { AppModule } from '../src/app.module';
+
+const ALLOWED_ORIGIN = 'http://test-origin.example.com';
+const UNTRUSTED_ORIGIN = 'http://untrusted.example.com';
+
+describe('CORS (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    process.env.CORS_ORIGIN = ALLOWED_ORIGIN;
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    app.enableCors({
+      origin: process.env.CORS_ORIGIN ? [process.env.CORS_ORIGIN] : undefined,
+      credentials: true,
+    });
+    await app.init();
+  });
+
+  afterEach(async () => {
+    delete process.env.CORS_ORIGIN;
+    await app.close();
+  });
+
+  it('OPTIONS preflight from allowed origin returns Access-Control-Allow-Origin', async () => {
+    await request(app.getHttpServer())
+      .options('/auth/login')
+      .set('Origin', ALLOWED_ORIGIN)
+      .set('Access-Control-Request-Method', 'POST')
+      .set('Access-Control-Request-Headers', 'Content-Type,Authorization')
+      .expect((res) => {
+        expect(res.headers['access-control-allow-origin']).toBe(ALLOWED_ORIGIN);
+      });
+  });
+
+  it('POST from allowed origin includes Access-Control-Allow-Origin in response', async () => {
+    await request(app.getHttpServer())
+      .post('/auth/login')
+      .set('Origin', ALLOWED_ORIGIN)
+      .send({ username: 'x', password: 'x' })
+      .expect((res) => {
+        expect(res.headers['access-control-allow-origin']).toBe(ALLOWED_ORIGIN);
+      });
+  });
+
+  it('request from untrusted origin does not receive Access-Control-Allow-Origin header', async () => {
+    await request(app.getHttpServer())
+      .post('/auth/login')
+      .set('Origin', UNTRUSTED_ORIGIN)
+      .send({ username: 'x', password: 'x' })
+      .expect((res) => {
+        expect(res.headers['access-control-allow-origin']).toBeUndefined();
+      });
+  });
+});

--- a/backend/test/cors.e2e-spec.ts
+++ b/backend/test/cors.e2e-spec.ts
@@ -26,9 +26,12 @@ describe('CORS (e2e)', () => {
         transform: true,
       }),
     );
+    const corsOrigin = process.env.CORS_ORIGIN
+      ? new URL(process.env.CORS_ORIGIN).origin
+      : undefined;
+
     app.enableCors({
-      origin: process.env.CORS_ORIGIN ? [process.env.CORS_ORIGIN] : undefined,
-      credentials: true,
+      origin: corsOrigin ? [corsOrigin] : undefined,
     });
     await app.init();
   });
@@ -38,7 +41,7 @@ describe('CORS (e2e)', () => {
     await app.close();
   });
 
-  it('OPTIONS preflight from allowed origin returns Access-Control-Allow-Origin', async () => {
+  it('OPTIONS preflight from allowed origin returns Access-Control-Allow-Origin and Vary: Origin', async () => {
     await request(app.getHttpServer())
       .options('/auth/login')
       .set('Origin', ALLOWED_ORIGIN)
@@ -46,6 +49,18 @@ describe('CORS (e2e)', () => {
       .set('Access-Control-Request-Headers', 'Content-Type,Authorization')
       .expect((res) => {
         expect(res.headers['access-control-allow-origin']).toBe(ALLOWED_ORIGIN);
+        expect(res.headers['vary']).toContain('Origin');
+      });
+  });
+
+  it('OPTIONS preflight from untrusted origin does not receive Access-Control-Allow-Origin header', async () => {
+    await request(app.getHttpServer())
+      .options('/auth/login')
+      .set('Origin', UNTRUSTED_ORIGIN)
+      .set('Access-Control-Request-Method', 'POST')
+      .set('Access-Control-Request-Headers', 'Content-Type,Authorization')
+      .expect((res) => {
+        expect(res.headers['access-control-allow-origin']).toBeUndefined();
       });
   });
 

--- a/backend/test/jest-e2e-setup.ts
+++ b/backend/test/jest-e2e-setup.ts
@@ -1,0 +1,4 @@
+// Set required environment variables for e2e tests.
+// These override missing values only — real values from process.env take precedence.
+process.env.OPENROUTER_API_KEY ??= 'test-placeholder';
+process.env.OPENROUTER_MODEL ??= 'test/model';

--- a/backend/test/jest-e2e.json
+++ b/backend/test/jest-e2e.json
@@ -5,5 +5,6 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
-  }
+  },
+  "setupFiles": ["<rootDir>/jest-e2e-setup.ts"]
 }

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+# Base URL for backend API requests.
+# Set to the EC2 backend URL in production (e.g. https://your-ec2-domain.com).
+# Leave empty in development: Vite proxy at /api handles routing to http://localhost:3001.
+VITE_API_BASE_URL=

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,4 @@
+# Production API base URL — points at the EC2 backend over HTTPS.
+# Baked into the Vite build at compile time via import.meta.env.VITE_API_BASE_URL.
+# No secrets here; the EC2 IP is public information.
+VITE_API_BASE_URL=https://3.72.241.64/api

--- a/frontend/src/api/authService.test.ts
+++ b/frontend/src/api/authService.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock useAuthStore before importing authService to avoid Zustand store initialization.
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: {
+    getState: vi.fn(() => ({
+      accessToken: null,
+      refreshTokens: vi.fn().mockResolvedValue(undefined),
+    })),
+  },
+}));
+
+// Import after mocks are in place.
+import { authService } from './authService';
+
+const MOCK_FETCH_RESPONSE = new Response(JSON.stringify({ user: {}, tokens: {} }), {
+  status: 200,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+describe('authService URL construction', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(MOCK_FETCH_RESPONSE.clone()));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('uses VITE_API_BASE_URL when set', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com');
+
+    await authService.login({ username: 'user', password: 'pass' }).catch(() => {});
+
+    const [calledUrl] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
+    expect(calledUrl).toBe('https://api.example.com/auth/login');
+  });
+
+  it('falls back to /api when VITE_API_BASE_URL is not set', async () => {
+    // No stub — VITE_API_BASE_URL is undefined in the test environment by default.
+    // vi.unstubAllEnvs() in afterEach ensures cleanup from previous tests.
+    await authService.login({ username: 'user', password: 'pass' }).catch(() => {});
+
+    const [calledUrl] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
+    expect(calledUrl).toBe('/api/auth/login');
+  });
+});

--- a/frontend/src/api/authService.ts
+++ b/frontend/src/api/authService.ts
@@ -1,4 +1,5 @@
 import { useAuthStore } from '@/store/authStore';
+import { getApiBaseUrl } from './client';
 
 interface AuthResponse {
   user: {
@@ -26,7 +27,10 @@ interface RegisterCredentials {
 }
 
 class AuthService {
-  private baseUrl = '/api';
+  private get baseUrl() {
+    return getApiBaseUrl();
+  }
+
   private isRefreshing = false;
   private refreshPromise: Promise<void> | null = null;
 
@@ -37,7 +41,6 @@ class AuthService {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(credentials),
-      credentials: 'include',
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Goal
Enable the GitHub Pages frontend to call the EC2 backend without browser CORS or mixed-content blocks.

## Changes
- `backend/src/main.ts` — add `app.enableCors()` reading `CORS_ORIGIN` env var; normalize with `new URL(...).origin` (fail-fast on malformed value)
- `backend/test/cors.e2e-spec.ts` — CORS e2e: allowed/blocked origin, allowed/blocked preflight, `Vary: Origin`
- `frontend/.env.production` — `VITE_API_BASE_URL=https://3.72.241.64/api` baked into GitHub Pages build
- `frontend/src/api/authService.ts` — replace hardcoded `baseUrl = '/api'` with `getApiBaseUrl()`; remove `credentials: 'include'`
- `.env.example` files updated for both backend and frontend

## How to test
```bash
cd backend && npm test && npm run test:e2e
cd frontend && npm test

# Smoke test
CORS_ORIGIN=http://localhost:5173 npm run start:dev
curl -sI -H "Origin: http://localhost:5173" http://localhost:3001/health | grep access-control
# → access-control-allow-origin: http://localhost:5173
```

## Docs/Contracts updated
None.

## Risks
- `CORS_ORIGIN` unset in production → browser blocks all cross-origin calls. Documented in `.env.example`.
- `frontend/.env.production` committed — contains only the public EC2 IP, no secrets.