### PR TITLE
feat: add light theme in the terminal

### DIFF
--- a/frontend/src/ui/components/AchievementStars.tsx
+++ b/frontend/src/ui/components/AchievementStars.tsx
@@ -32,8 +32,8 @@ export function AchievementStars({ total, completed, size = 20, className = '' }
             viewBox="0 0 24 24"
             className={`transition-all duration-300 ${
               isFilled
-                ? 'text-amber-300 drop-shadow-[0_0_10px_rgba(251,191,36,0.45)]'
-                : 'text-slate-500/70'
+                ? 'text-amber-300 drop-shadow-[0_0_10px_rgba(251,191,36,0.45)] dark:text-indigo-400 dark:drop-shadow-[0_0_10px_rgba(129,140,248,0.35)]'
+                : 'text-slate-500/70 dark:text-slate-400/70'
             } ${isNew ? 'scale-110' : ''}`}
             fill={isFilled ? 'currentColor' : 'none'}
             stroke="currentColor"

--- a/frontend/src/ui/screens/library/sections/LibraryLessonDetails.tsx
+++ b/frontend/src/ui/screens/library/sections/LibraryLessonDetails.tsx
@@ -37,7 +37,7 @@ export function LibraryLessonDetails({
           </p>
           <h2
             id="library-lesson-title"
-            className="text-xl font-semibold text-yellow-50 sm:text-2xl"
+            className="text-xl font-semibold text-yellow-50 sm:text-2xl dark:text-mist-900"
           >
             {lesson.title}
           </h2>
@@ -50,7 +50,7 @@ export function LibraryLessonDetails({
           />
           <span
             aria-live="polite"
-            className="text-[11px] uppercase tracking-[0.1em] text-amber-200/80"
+            className="text-[11px] uppercase tracking-[0.1em] text-amber-200/80 dark:text-mist-900/70"
           >
             {t('library.steps', {
               completed: progress.completed,
@@ -62,40 +62,49 @@ export function LibraryLessonDetails({
 
       <div className="mt-4 space-y-4 text-sm leading-relaxed">
         <div className="space-y-1.5" aria-labelledby={theoryTitleId}>
-          <h3 id={theoryTitleId} className="font-semibold text-yellow-100">
+          <h3
+            id={theoryTitleId}
+            className="font-semibold text-yellow-100 dark:text-mist-900"
+          >
             {t('library.theory')}
           </h3>
-          <p className="whitespace-pre-wrap text-yellow-100/80">
+          <p className="whitespace-pre-wrap text-yellow-100/80 dark:text-mist-900/85">
             {lesson.theoryMarkdown || t('common.notSet')}
           </p>
         </div>
         <div className="space-y-1.5" aria-labelledby={taskTitleId}>
-          <h3 id={taskTitleId} className="font-semibold text-yellow-100">
+          <h3
+            id={taskTitleId}
+            className="font-semibold text-yellow-100 dark:text-mist-900"
+          >
             {t('library.task')}
           </h3>
-          <p className="whitespace-pre-wrap text-yellow-100/80">
+          <p className="whitespace-pre-wrap text-yellow-100/80 dark:text-mist-900/85">
             {lesson.taskDescription || t('common.notSet')}
           </p>
         </div>
         {lesson.hints.length > 0 ? (
           <div className="space-y-1.5" aria-labelledby={hintsTitleId}>
-            <h3 id={hintsTitleId} className="font-semibold text-yellow-100">
+            <h3
+              id={hintsTitleId}
+              className="font-semibold text-yellow-100 dark:text-mist-900"
+            >
               {t('library.hints')}
             </h3>
-            <div className="rounded-md border border-yellow-400/20 bg-white/5">
+            <div className="rounded-md border border-yellow-400/20 bg-white/5 dark:border-mist-400 dark:bg-mist-100">
               <button
                 type="button"
                 aria-expanded={areHintsVisible}
                 aria-controls={hintsContentId}
                 onClick={() => setAreHintsVisible((current) => !current)}
-                className="w-full cursor-pointer px-3 py-2 text-left text-sm font-medium text-yellow-100"
+                className="w-full cursor-pointer px-3 py-2 text-left text-sm font-medium text-yellow-100 dark:text-mist-900"
               >
                 {t('library.hints')}
               </button>
               {areHintsVisible ? (
                 <ul
                   id={hintsContentId}
-                  className="space-y-1 border-t border-yellow-400/15 px-3 py-3 text-yellow-100/80"
+                  className="space-y-1 border-t border-yellow-400/15 px-3 py-3 text-yellow-100/80 dark:border-mist-400 dark:text-mist-900/85"
                 >
                   {lesson.hints.map((hint) => (
                     <li key={hint}>{hint}</li>

--- a/frontend/src/ui/screens/library/sections/TerminalWindow.tsx
+++ b/frontend/src/ui/screens/library/sections/TerminalWindow.tsx
@@ -134,13 +134,18 @@ export function TerminalWindow({ height, className }: Props) {
   }, [prompt]);
 
   useEffect(() => {
+    const initialIsLightTheme =
+      typeof document !== 'undefined'
+        ? document.documentElement.classList.contains('dark')
+        : false;
+
     const term = new Terminal({
       convertEol: true,
       cursorBlink: true,
       fontFamily: 'JetBrains Mono, SFMono-Regular, Menlo, monospace',
       fontSize: 14,
       rows: 24,
-      theme: getTerminalTheme(isLightTheme),
+      theme: getTerminalTheme(initialIsLightTheme),
     });
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
@@ -304,6 +309,10 @@ export function TerminalWindow({ height, className }: Props) {
   useEffect(() => {
     const term = termRef.current;
     if (!term) return;
+
+    if (!('options' in term) || typeof term.options === 'undefined') {
+      return;
+    }
 
     term.options.theme = getTerminalTheme(isLightTheme);
   }, [isLightTheme]);

--- a/frontend/src/ui/screens/library/sections/TerminalWindow.tsx
+++ b/frontend/src/ui/screens/library/sections/TerminalWindow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import 'xterm/css/xterm.css';
@@ -17,6 +17,34 @@ const COLORS: Record<'stdout' | 'stderr' | 'system', string> = {
   system: '\u001b[96m',
 };
 
+function getTerminalTheme(isLightTheme: boolean) {
+  if (isLightTheme) {
+    return {
+      background: '#f8fafc',
+      foreground: '#0f172a',
+      cursor: '#475569',
+      black: '#e2e8f0',
+      green: '#166534',
+      red: '#b91c1c',
+      yellow: '#a16207',
+      blue: '#1d4ed8',
+      magenta: '#7c3aed',
+      cyan: '#0f766e',
+      white: '#0f172a',
+      brightBlack: '#94a3b8',
+      brightWhite: '#020617',
+    };
+  }
+
+  return {
+    background: '#000000',
+    foreground: '#f8f6e5',
+    cursor: '#facc15',
+    black: '#000000',
+    green: '#bbf7d0',
+  };
+}
+
 function formatPromptPath(cwd: string) {
   const home = '/home/student';
   if (cwd === home) return '~';
@@ -32,6 +60,11 @@ export function TerminalWindow({ height, className }: Props) {
   const runCommand = useTerminalSession((s) => s.runCommand);
   const history = useTerminalSession((s) => s.history);
   const isTerminalBusy = useTerminalSession((s) => s.isTerminalBusy);
+  const [isLightTheme, setIsLightTheme] = useState(() =>
+    typeof document !== 'undefined'
+      ? document.documentElement.classList.contains('dark')
+      : false,
+  );
 
   const prompt = useMemo(() => `student@dojo:${formatPromptPath(cwd)}$ `, [cwd]);
 
@@ -62,6 +95,32 @@ export function TerminalWindow({ height, className }: Props) {
   }, [isTerminalBusy]);
 
   useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const syncTheme = () => {
+      setIsLightTheme(document.documentElement.classList.contains('dark'));
+    };
+
+    syncTheme();
+
+    const observer =
+      typeof MutationObserver === 'undefined'
+        ? null
+        : new MutationObserver(() => {
+            syncTheme();
+          });
+
+    observer?.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+
+    return () => observer?.disconnect();
+  }, []);
+
+  useEffect(() => {
     promptRef.current = prompt;
     const term = termRef.current;
     if (!term) return;
@@ -81,13 +140,7 @@ export function TerminalWindow({ height, className }: Props) {
       fontFamily: 'JetBrains Mono, SFMono-Regular, Menlo, monospace',
       fontSize: 14,
       rows: 24,
-      theme: {
-        background: '#000000',
-        foreground: '#f8f6e5',
-        cursor: '#facc15',
-        black: '#000000',
-        green: '#bbf7d0',
-      },
+      theme: getTerminalTheme(isLightTheme),
     });
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
@@ -252,6 +305,13 @@ export function TerminalWindow({ height, className }: Props) {
     const term = termRef.current;
     if (!term) return;
 
+    term.options.theme = getTerminalTheme(isLightTheme);
+  }, [isLightTheme]);
+
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+
     if (lastOutputIndexRef.current > output.length) {
       term.clear();
       lastOutputIndexRef.current = 0;
@@ -298,7 +358,7 @@ export function TerminalWindow({ height, className }: Props) {
   return (
     <div
       ref={rootRef}
-      className={`flex flex-col rounded-lg border border-yellow-400/25 bg-mist-950/80 shadow-lg backdrop-blur-sm overflow-hidden min-h-0 max-h-full dark:bg-mist-200 dark:border-mist-200 ${className ?? ''}`}
+      className={`flex min-h-0 max-h-full flex-col overflow-hidden rounded-lg border border-yellow-400/25 bg-mist-950/80 shadow-lg backdrop-blur-sm dark:border-mist-300 dark:bg-mist-100 ${className ?? ''}`}
       style={height ? { height } : undefined}
     >
       <div className="flex items-center gap-2 border-b border-yellow-400/15 px-3 py-2 text-[11px] uppercase tracking-[0.08em] text-yellow-200/80 dark:text-mist-900 dark:border-mist-300">
@@ -309,7 +369,7 @@ export function TerminalWindow({ height, className }: Props) {
       <div className="flex-1 min-h-0 max-h-full px-3 py-3 scrollbar-thin">
         <div
           ref={containerRef}
-          className="h-full w-full rounded-md border border-yellow-400/20 bg-[radial-gradient(circle_at_20%_20%,rgba(250,204,21,0.08),transparent_45%),radial-gradient(circle_at_80%_10%,rgba(56,189,248,0.07),transparent_40%),#0b0f19] shadow-inner dark:border-mist-300"
+          className="h-full w-full rounded-md border border-yellow-400/20 bg-[radial-gradient(circle_at_20%_20%,rgba(250,204,21,0.08),transparent_45%),radial-gradient(circle_at_80%_10%,rgba(56,189,248,0.07),transparent_40%),#0b0f19] shadow-inner dark:border-mist-300 dark:bg-[linear-gradient(180deg,#ffffff_0%,#eef2f6_100%)]"
         />
       </div>
     </div>


### PR DESCRIPTION
Summary
This PR improves the light theme experience in the learning screen and removes readability issues in the terminal/task area.

What changed
updated the terminal component to use a proper light-theme xterm palette instead of keeping the terminal black in light mode
improved light-theme readability in the lesson details block by switching headings, task text, theory text, hints, and progress text to dark readable colors
aligned completed progress stars with the light-theme visual language by switching the filled star color to an indigo-based accent in light mode
Affected areas
frontend/src/ui/screens/library/sections/TerminalWindow.tsx
frontend/src/ui/screens/library/sections/LibraryLessonDetails.tsx
frontend/src/ui/components/AchievementStars.tsx