### PR TITLE
feat(frontend): add light theme support for assistant panel

### DIFF
--- a/frontend/src/features/assistant/ui/AssistantMessageMarkdown.tsx
+++ b/frontend/src/features/assistant/ui/AssistantMessageMarkdown.tsx
@@ -10,15 +10,17 @@ export function AssistantMessageMarkdown({ content }: AssistantMessageMarkdownPr
       <ReactMarkdown
         components={{
           p: ({ children }) => (
-            <p className="whitespace-pre-wrap wrap-break-word">{children}</p>
+            <p className="whitespace-pre-wrap wrap-break-word text-inherit">{children}</p>
           ),
-          ul: ({ children }) => <ul className="list-disc space-y-1 pl-5">{children}</ul>,
+          ul: ({ children }) => (
+            <ul className="list-disc space-y-1 pl-5 text-inherit">{children}</ul>
+          ),
           ol: ({ children }) => (
-            <ol className="list-decimal space-y-1 pl-5">{children}</ol>
+            <ol className="list-decimal space-y-1 pl-5 text-inherit">{children}</ol>
           ),
           li: ({ children }) => <li className="wrap-break-word">{children}</li>,
           pre: ({ children }) => (
-            <pre className="overflow-x-auto rounded-xl bg-black/40 px-3 py-2 [&>code]:bg-transparent [&>code]:p-0 [&>code]:text-slate-100 [&>code]:font-mono [&>code]:text-[0.9em]">
+            <pre className="overflow-x-auto rounded-xl border border-yellow-400/10 bg-mist-950/85 px-3 py-2 text-slate-100 shadow-[0_8px_20px_rgba(0,0,0,0.16)] dark:border-mist-400 dark:bg-mist-100 dark:text-mist-900 dark:shadow-[0_8px_20px_rgba(15,23,42,0.06)] [&>code]:bg-transparent [&>code]:p-0 [&>code]:text-inherit [&>code]:font-mono [&>code]:text-[0.9em]">
               {children}
             </pre>
           ),
@@ -28,14 +30,16 @@ export function AssistantMessageMarkdown({ content }: AssistantMessageMarkdownPr
               className={
                 className
                   ? className
-                  : 'rounded bg-black/30 px-1.5 py-0.5 font-mono text-[0.9em] text-yellow-100'
+                  : 'rounded-md border border-yellow-400/10 bg-mist-950/75 px-1.5 py-0.5 font-mono text-[0.9em] text-yellow-100 dark:border-mist-400 dark:bg-mist-100 dark:text-mist-900'
               }
             >
               {children}
             </code>
           ),
           strong: ({ children }) => (
-            <strong className="font-semibold text-white">{children}</strong>
+            <strong className="font-semibold text-yellow-50 dark:text-mist-900">
+              {children}
+            </strong>
           ),
         }}
       >

--- a/frontend/src/features/assistant/ui/AssistantPanel.tsx
+++ b/frontend/src/features/assistant/ui/AssistantPanel.tsx
@@ -1,19 +1,19 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
+import { SendIcon } from '@/components/ui/icons/SendIcon';
+import { StopIcon } from '@/components/ui/icons/StopIcon';
 import { useI18n } from '@/i18n/useI18n';
 
+import { getAssistantHistory } from '../api/assistantApi';
 import {
   AssistantStreamStoppedByUserError,
   startAssistantStream,
   type AssistantStreamSession,
 } from '../api/assistantStreamApi';
-import { getAssistantHistory } from '../api/assistantApi';
 import type { AssistantMessage } from '../model/assistant.interfaces';
 import { useAssistantStore } from '../model/assistantStore';
 import type { AssistantPanelProps, AssistantUiPhase } from '../model/assistant.types';
 import { AssistantMessageMarkdown } from './AssistantMessageMarkdown';
-import { SendIcon } from '@/components/ui/icons/SendIcon';
-import { StopIcon } from '@/components/ui/icons/StopIcon';
 
 const createMessageId = (): string => {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -67,14 +67,14 @@ const getAssistantErrorMessage = (
 
 const getMessageBubbleClassName = (message: AssistantMessage): string => {
   if (message.role === 'user') {
-    return 'ml-auto max-w-[85%] rounded-2xl rounded-br-md border border-yellow-400/25 bg-yellow-400/10 px-4 py-3 text-sm text-yellow-50 shadow-[0_8px_24px_rgba(0,0,0,0.18)]';
+    return 'ml-auto max-w-[85%] rounded-2xl rounded-br-md border border-yellow-400/25 bg-yellow-400/10 px-4 py-3 text-sm text-yellow-50 shadow-[0_8px_24px_rgba(0,0,0,0.18)] dark:border-mist-400 dark:bg-mist-100 dark:text-mist-900 dark:shadow-[0_8px_20px_rgba(15,23,42,0.08)]';
   }
 
   if (message.role === 'system') {
-    return 'mx-auto max-w-[92%] rounded-2xl border border-yellow-400/10 bg-mist-900/70 px-4 py-3 text-center text-sm text-slate-300';
+    return 'mx-auto max-w-[92%] rounded-2xl border border-yellow-400/10 bg-mist-900/70 px-4 py-3 text-center text-sm text-slate-300 dark:border-mist-400 dark:bg-white/90 dark:text-mist-900/80';
   }
 
-  return 'mr-auto max-w-[85%] rounded-2xl rounded-bl-md border border-yellow-400/12 bg-mist-900/80 px-4 py-3 text-sm text-slate-100 shadow-[0_8px_24px_rgba(0,0,0,0.16)]';
+  return 'mr-auto max-w-[85%] rounded-2xl rounded-bl-md border border-yellow-400/12 bg-mist-900/80 px-4 py-3 text-sm text-slate-100 shadow-[0_8px_24px_rgba(0,0,0,0.16)] dark:border-mist-400 dark:bg-white/90 dark:text-mist-900 dark:shadow-[0_8px_20px_rgba(15,23,42,0.08)]';
 };
 
 const isScrolledNearBottom = (element: HTMLDivElement): boolean => {
@@ -102,6 +102,7 @@ export function AssistantPanel({ attemptId }: AssistantPanelProps) {
   const setDraft = useAssistantStore((state) => state.setDraft);
   const addUserMessage = useAssistantStore((state) => state.addUserMessage);
   const startAssistantMessage = useAssistantStore((state) => state.startAssistantMessage);
+  const stopAssistantMessage = useAssistantStore((state) => state.stopAssistantMessage);
   const resetLastAssistantTurn = useAssistantStore(
     (state) => state.resetLastAssistantTurn,
   );
@@ -110,12 +111,12 @@ export function AssistantPanel({ attemptId }: AssistantPanelProps) {
     (state) => state.completeAssistantMessage,
   );
   const failAssistantMessage = useAssistantStore((state) => state.failAssistantMessage);
-  const stopAssistantMessage = useAssistantStore((state) => state.stopAssistantMessage);
   const setAutoScrollMode = useAssistantStore((state) => state.setAutoScrollMode);
 
   const sessionState = useAssistantStore((state) =>
     attemptId ? state.sessionsByAttemptId[attemptId] : undefined,
   );
+
   const draft = sessionState?.draft ?? '';
   const messages = sessionState?.messages ?? [];
   const phase = sessionState?.phase ?? 'idle';
@@ -331,7 +332,7 @@ export function AssistantPanel({ attemptId }: AssistantPanelProps) {
       <button
         type="button"
         onClick={() => setIsOpen(true)}
-        className="fixed bottom-6 right-6 z-50 rounded-full border border-yellow-500/30 bg-yellow-400 px-5 py-3 text-sm font-medium text-black shadow-lg transition-all duration-200 ease-out hover:bg-gray-900 hover:text-yellow-400 hover:shadow-[0_0_20px_rgba(250,204,21,0.8)]"
+        className="fixed bottom-6 right-6 z-50 rounded-full border border-yellow-500/30 bg-yellow-400 px-5 py-3 text-sm font-medium text-black shadow-lg transition-all duration-200 ease-out hover:bg-gray-900 hover:text-yellow-400 hover:shadow-[0_0_20px_rgba(250,204,21,0.8)] dark:border-mist-500 dark:bg-mist-900 dark:text-mist-100 dark:hover:bg-mist-800 dark:hover:text-mist-50"
       >
         {t('assistant.title')}
       </button>
@@ -339,16 +340,18 @@ export function AssistantPanel({ attemptId }: AssistantPanelProps) {
   }
 
   return (
-    <aside className="fixed inset-x-4 bottom-4 z-50 flex h-[min(42rem,calc(100vh-5rem))] w-auto flex-col overflow-hidden rounded-3xl border border-yellow-400/20 bg-linear-to-b from-mist-950 to-mist-900 shadow-[0_20px_70px_rgba(0,0,0,0.5)] ring-1 ring-yellow-400/8 backdrop-blur-xl sm:right-5 sm:left-auto sm:w-md lg:w-120">
-      <header className="flex items-center justify-between border-b border-yellow-400/10 px-5 py-4">
+    <aside className="fixed inset-x-4 bottom-4 z-50 flex h-[min(42rem,calc(100vh-5rem))] w-auto flex-col overflow-hidden rounded-3xl border border-yellow-400/20 bg-linear-to-b from-mist-950 to-mist-900 shadow-[0_20px_70px_rgba(0,0,0,0.5)] ring-1 ring-yellow-400/8 backdrop-blur-xl sm:right-5 sm:left-auto sm:w-md lg:w-120 dark:border-mist-400/70 dark:bg-none dark:bg-mist-300 dark:ring-mist-500/20 dark:shadow-[0_20px_60px_rgba(15,23,42,0.16)]">
+      <header className="flex items-center justify-between border-b border-yellow-400/10 px-5 py-4 dark:border-mist-400/70">
         <div>
-          <h2 className="text-base font-semibold text-yellow-50 sm:text-lg">
+          <h2 className="text-base font-semibold text-yellow-50 sm:text-lg dark:text-mist-900">
             {t('assistant.title')}
           </h2>
           <div className="flex items-center gap-2">
-            <p className="text-xs font-semibold text-yellow-100/70">{statusLabel}</p>
+            <p className="text-xs font-semibold text-yellow-100/75 dark:text-mist-900/70">
+              {statusLabel}
+            </p>
             {hasUnreadAssistantDelta ? (
-              <span className="rounded-full border border-yellow-400/20 bg-yellow-400/8 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-yellow-100">
+              <span className="rounded-full border border-yellow-400/20 bg-yellow-400/8 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-yellow-100 dark:border-mist-400 dark:bg-mist-100 dark:text-mist-900">
                 {t('assistant.newBadge')}
               </span>
             ) : null}
@@ -358,7 +361,7 @@ export function AssistantPanel({ attemptId }: AssistantPanelProps) {
         <button
           type="button"
           onClick={() => setIsOpen(false)}
-          className="rounded-full p-1 text-lg font-bold text-slate-300 transition hover:bg-yellow-400/6 hover:text-yellow-300"
+          className="rounded-full p-1 text-lg font-bold text-slate-300 transition hover:bg-yellow-400/6 hover:text-yellow-300 dark:text-mist-900/75 dark:hover:bg-mist-200 dark:hover:text-mist-900"
         >
           ×
         </button>
@@ -370,15 +373,15 @@ export function AssistantPanel({ attemptId }: AssistantPanelProps) {
         className="flex-1 overflow-y-auto bg-transparent px-4 py-4 sm:px-5"
       >
         {!isAssistantAvailable ? (
-          <div className="flex h-full min-h-56 items-center justify-center rounded-2xl border border-dashed border-yellow-400/12 bg-mist-900/65 px-4 text-center text-sm text-yellow-100/70">
+          <div className="flex h-full min-h-56 items-center justify-center rounded-2xl border border-dashed border-yellow-400/12 bg-mist-900/65 px-4 text-center text-sm text-yellow-100/70 dark:border-mist-400 dark:bg-mist-100 dark:text-mist-900/75">
             {t('assistant.unavailable')}
           </div>
         ) : isHistoryLoading ? (
-          <div className="flex h-full min-h-56 items-center justify-center rounded-2xl border border-dashed border-yellow-400/12 bg-mist-900/65 px-4 text-center text-sm text-yellow-100/70">
+          <div className="flex h-full min-h-56 items-center justify-center rounded-2xl border border-dashed border-yellow-400/12 bg-mist-900/65 px-4 text-center text-sm text-yellow-100/70 dark:border-mist-400 dark:bg-mist-100 dark:text-mist-900/75">
             {t('assistant.loadingHistory')}
           </div>
         ) : messages.length === 0 ? (
-          <div className="flex h-full min-h-56 items-center justify-center rounded-2xl border border-dashed border-yellow-400/12 bg-mist-900/65 px-4 text-center text-sm text-yellow-100/70">
+          <div className="flex h-full min-h-56 items-center justify-center rounded-2xl border border-dashed border-yellow-400/12 bg-mist-900/65 px-4 text-center text-sm text-yellow-100/70 dark:border-mist-400 dark:bg-mist-100 dark:text-mist-900/75">
             {t('assistant.emptyState')}
           </div>
         ) : (
@@ -398,7 +401,7 @@ export function AssistantPanel({ attemptId }: AssistantPanelProps) {
                   key={message.id}
                   className={
                     isRetryableErrorMessage
-                      ? 'mr-auto max-w-[85%] rounded-2xl rounded-bl-md border border-red-400/18 bg-red-950/35 px-4 py-3 text-sm text-red-100 shadow-[0_8px_24px_rgba(0,0,0,0.14)]'
+                      ? 'mr-auto max-w-[85%] rounded-2xl rounded-bl-md border border-red-400/18 bg-red-950/35 px-4 py-3 text-sm text-red-100 shadow-[0_8px_24px_rgba(0,0,0,0.14)] dark:border-red-300/70 dark:bg-red-100 dark:text-red-900 dark:shadow-[0_8px_20px_rgba(15,23,42,0.08)]'
                       : getMessageBubbleClassName(message)
                   }
                 >
@@ -421,7 +424,7 @@ export function AssistantPanel({ attemptId }: AssistantPanelProps) {
                       onClick={() => {
                         void handleRetryLastQuestion();
                       }}
-                      className="mt-3 rounded-full border border-red-300/20 bg-white/5 px-3 py-1.5 text-xs font-semibold text-red-100 transition hover:border-red-200/35 hover:bg-white/8"
+                      className="mt-3 rounded-full border border-red-300/20 bg-white/5 px-3 py-1.5 text-xs font-semibold text-red-100 transition hover:border-red-200/35 hover:bg-white/8 dark:border-red-300 dark:bg-white dark:text-red-900 dark:hover:bg-red-50"
                     >
                       {t('assistant.retry')}
                     </button>
@@ -435,7 +438,7 @@ export function AssistantPanel({ attemptId }: AssistantPanelProps) {
                 <button
                   type="button"
                   onClick={handleJumpToLatest}
-                  className="rounded-full border border-yellow-400/18 bg-mist-900/95 px-3 py-2 text-xs font-medium text-yellow-200 shadow-[0_10px_28px_rgba(0,0,0,0.28)] transition hover:border-yellow-300/35 hover:bg-mist-900"
+                  className="rounded-full border border-yellow-400/18 bg-mist-950/95 px-3 py-2 text-xs font-medium text-yellow-200 shadow-[0_10px_28px_rgba(0,0,0,0.28)] transition hover:border-yellow-300/35 hover:bg-mist-900 dark:border-mist-400 dark:bg-white/95 dark:text-mist-900 dark:hover:bg-mist-100"
                 >
                   {hasUnreadAssistantDelta
                     ? t('assistant.jumpToLatestNew')
@@ -449,7 +452,7 @@ export function AssistantPanel({ attemptId }: AssistantPanelProps) {
         )}
       </div>
 
-      <footer className="border-t border-yellow-400/10 px-4 py-4 sm:px-5">
+      <footer className="border-t border-yellow-400/10 px-4 py-4 sm:px-5 dark:border-mist-400/70">
         <div className="flex items-center gap-2">
           <textarea
             value={draft}
@@ -462,7 +465,7 @@ export function AssistantPanel({ attemptId }: AssistantPanelProps) {
                 ? t('assistant.placeholderReady')
                 : t('assistant.placeholderUnavailable')
             }
-            className="min-h-24 flex-1 resize-none rounded-2xl border border-yellow-400/12 bg-mist-950/80 px-4 py-3 text-sm text-slate-100 outline-none transition placeholder:text-slate-500 focus:border-yellow-400/28 focus:bg-mist-900/85 disabled:cursor-not-allowed disabled:opacity-60"
+            className="min-h-24 flex-1 resize-none rounded-2xl border border-yellow-400/12 bg-mist-950/80 px-4 py-3 text-sm text-slate-100 outline-none transition placeholder:text-slate-500 focus:border-yellow-400/28 focus:bg-mist-900/85 disabled:cursor-not-allowed disabled:opacity-60 dark:border-mist-400 dark:bg-white dark:text-mist-900 dark:placeholder:text-mist-900/55 dark:focus:border-mist-500 dark:focus:bg-white"
           />
 
           {isRequestInFlight ? (
@@ -471,7 +474,7 @@ export function AssistantPanel({ attemptId }: AssistantPanelProps) {
               onClick={handleStopGeneration}
               aria-label={t('assistant.stop')}
               title={t('assistant.stop')}
-              className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-red-400/18 bg-red-950/35 text-red-100 transition hover:bg-red-900/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300/40"
+              className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-red-400/18 bg-red-950/35 text-red-100 transition hover:bg-red-900/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300/40 dark:border-red-300/70 dark:bg-red-100 dark:text-red-900 dark:hover:bg-red-200"
             >
               <StopIcon className="h-8 w-8" />
             </button>
@@ -484,7 +487,7 @@ export function AssistantPanel({ attemptId }: AssistantPanelProps) {
               aria-label={t('assistant.send')}
               title={t('assistant.send')}
               disabled={!attemptId || !draft.trim() || isHistoryLoading}
-              className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-yellow-400/20 bg-yellow-400 text-black shadow-[0_10px_24px_rgba(250,204,21,0.18)] transition hover:bg-yellow-300 hover:text-black disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-300/40"
+              className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-yellow-400/20 bg-yellow-400 text-black shadow-[0_10px_24px_rgba(250,204,21,0.18)] transition hover:bg-yellow-300 hover:text-black disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-300/40 dark:border-mist-500 dark:bg-mist-900 dark:text-mist-100 dark:hover:bg-mist-800"
             >
               <SendIcon className="h-8 w-8" />
             </button>


### PR DESCRIPTION
## Summary

This PR adds light theme support for the assistant panel in the Library screen.

## What changed

- updated `AssistantPanel` styles for both dark and light themes
- aligned assistant colors with the existing Library UI theme
- updated assistant bubbles, empty states, textarea, and action buttons
- added light theme support for `AssistantMessageMarkdown`
- improved readability of markdown content in light mode

## Result

The assistant now looks consistent with the rest of the Library page in both themes.

## Testing

Tested manually in:
- dark theme
- light theme

Checked:
- panel shell
- message bubbles
- textarea
- send / stop buttons
- markdown rendering