### PR TITLE
fix(frontend): correct production API base URL

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,4 +1,4 @@
 # Production API base URL — points at the EC2 backend over HTTPS.
 # Baked into the Vite build at compile time via import.meta.env.VITE_API_BASE_URL.
 # No secrets here; the EC2 IP is public information.
-VITE_API_BASE_URL=https://3.72.241.64/api
+VITE_API_BASE_URL=https://3.72.241.64


### PR DESCRIPTION
## Summary

Fix the production frontend API base URL.

## Why

The deployed backend currently serves routes without the `/api` prefix, while the production frontend was calling `https://3.72.241.64/api/...`.

This caused `404 Not Found` errors for auth and other API requests on the deployed site.

## What changed

- updated `frontend/.env.production`
- changed `VITE_API_BASE_URL` from `https://3.72.241.64/api` to `https://3.72.241.64`

## Result

The frontend will call the currently available backend routes correctly:
- `/auth/login`
- `/auth/register`
- `/profile/me`
- `/learning/overview`
- and other existing endpoints without the `/api` prefix